### PR TITLE
feat: add ready check

### DIFF
--- a/crates/arkflow-core/src/input/mod.rs
+++ b/crates/arkflow-core/src/input/mod.rs
@@ -51,6 +51,11 @@ pub trait Input: Send + Sync {
 
     /// Close the input source connection
     async fn close(&self) -> Result<(), Error>;
+
+    /// Check if the input source is ready and healthy
+    async fn check_ready(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 pub struct NoopAck;

--- a/crates/arkflow-core/src/output/mod.rs
+++ b/crates/arkflow-core/src/output/mod.rs
@@ -37,6 +37,11 @@ pub trait Output: Send + Sync {
 
     /// Close the output destination connection
     async fn close(&self) -> Result<(), Error>;
+
+    /// Check if the output destination is ready and healthy
+    async fn check_ready(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Output configuration

--- a/crates/arkflow-core/src/stream/mod.rs
+++ b/crates/arkflow-core/src/stream/mod.rs
@@ -425,6 +425,18 @@ impl Stream {
 
         Ok(())
     }
+
+    pub fn get_input(&self) -> Arc<dyn Input> {
+        self.input.clone()
+    }
+
+    pub fn get_output(&self) -> Arc<dyn Output> {
+        self.output.clone()
+    }
+
+    pub fn get_error_output(&self) -> Option<Arc<dyn Output>> {
+        self.error_output.clone()
+    }
 }
 
 /// Stream configuration


### PR DESCRIPTION
Implement #768 
This PR only cover interface part, concrete implementation of `ready` for each input/output will be implement next 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * More accurate readiness: computed from all stream components rather than a fixed flag.
  * Inputs and outputs can optionally report readiness, improving health diagnostics.
  * Health and liveness endpoints use a unified engine state; liveness reports alive when reachable.

* **Refactor**
  * Health check server starts after streams are initialized to ensure reliable readiness.
  * Internal restructuring to support richer health reporting without breaking existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->