### PR TITLE
feat: add durable input WAL with crash recovery (at-least-once across crashes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "num_cpus",
+ "redb",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2128,7 +2129,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3552,7 +3553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4469,7 +4470,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5551,7 +5552,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5704,7 +5705,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -5941,7 +5942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6829,7 +6830,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6867,9 +6868,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7031,6 +7032,15 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7501,7 +7511,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7594,7 +7604,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8729,7 +8739,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8738,7 +8748,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10026,7 +10036,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sqlx = { version = "0.8", features = ["mysql", "postgres", "runtime-tokio", "tls
 
 tempfile = "3.24.0"
 mockall = "0.14"
+redb = "2"
 arkflow-core = { path = "crates/arkflow-core" }
 arkflow-plugin = { path = "crates/arkflow-plugin" }
 

--- a/crates/arkflow-core/Cargo.toml
+++ b/crates/arkflow-core/Cargo.toml
@@ -27,4 +27,5 @@ clap = { workspace = true }
 colored = { workspace = true }
 flume = { workspace = true }
 axum = { workspace = true }
+redb = { workspace = true }
 num_cpus = "1.17.0"

--- a/crates/arkflow-core/src/input/mod.rs
+++ b/crates/arkflow-core/src/input/mod.rs
@@ -41,7 +41,14 @@ pub trait InputBuilder: Send + Sync {
 
 #[async_trait]
 pub trait Ack: Send + Sync {
-    async fn ack(&self);
+    /// Acknowledge the message.
+    ///
+    /// Returns `Err` if the acknowledgement could not be completed (e.g. a
+    /// durable cursor could not be advanced or a source-side commit failed).
+    /// A returned `Err` does not lose data under at-least-once semantics — the
+    /// unacknowledged message will be re-delivered — but it lets the stream
+    /// observe the failure to apply backpressure or stop.
+    async fn ack(&self) -> Result<(), Error>;
 }
 
 #[async_trait]
@@ -60,17 +67,20 @@ pub struct NoopAck;
 
 #[async_trait]
 impl Ack for NoopAck {
-    async fn ack(&self) {}
+    async fn ack(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 pub struct VecAck(pub Vec<Arc<dyn Ack>>);
 
 #[async_trait]
 impl Ack for VecAck {
-    async fn ack(&self) {
+    async fn ack(&self) -> Result<(), Error> {
         for ack in &self.0 {
-            ack.ack().await;
+            ack.ack().await?;
         }
+        Ok(())
     }
 }
 

--- a/crates/arkflow-core/src/lib.rs
+++ b/crates/arkflow-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod pipeline;
 pub mod processor;
 pub mod stream;
 pub mod temporary;
+pub mod wal;
 
 #[cfg(test)]
 mod message_batch_tests;

--- a/crates/arkflow-core/src/stream/mod.rs
+++ b/crates/arkflow-core/src/stream/mod.rs
@@ -17,7 +17,8 @@
 //! A stream is a complete data processing unit, containing input, pipeline, and output.
 
 use crate::buffer::Buffer;
-use crate::input::Ack;
+use crate::input::{Ack, NoopAck};
+use crate::wal::{Wal, WalAck, WalConfig};
 use crate::{
     input::Input, output::Output, pipeline::Pipeline, Error, MessageBatchRef, ProcessResult,
     Resource,
@@ -41,6 +42,7 @@ pub struct Stream {
     error_output: Option<Arc<dyn Output>>,
     thread_num: u32,
     buffer: Option<Arc<dyn Buffer>>,
+    wal: Option<Arc<Wal>>,
     resource: Resource,
     sequence_counter: Arc<AtomicU64>,
     next_seq: Arc<AtomicU64>,
@@ -59,6 +61,7 @@ impl Stream {
         output: Arc<dyn Output>,
         error_output: Option<Arc<dyn Output>>,
         buffer: Option<Arc<dyn Buffer>>,
+        wal: Option<Arc<Wal>>,
         resource: Resource,
         thread_num: u32,
     ) -> Self {
@@ -68,6 +71,7 @@ impl Stream {
             output,
             error_output,
             buffer,
+            wal,
             resource,
             thread_num,
             sequence_counter: Arc::new(AtomicU64::new(0)),
@@ -100,6 +104,7 @@ impl Stream {
             self.input.clone(),
             input_sender.clone(),
             self.buffer.clone(),
+            self.wal.clone(),
         ));
 
         // Buffer
@@ -148,12 +153,54 @@ impl Stream {
         Ok(())
     }
 
+    /// Forward a (message, ack) pair to the buffer if present, otherwise to the
+    /// processor input channel. Shared by normal ingestion and WAL recovery.
+    async fn forward(
+        msg: MessageBatchRef,
+        ack: Arc<dyn Ack>,
+        buffer_option: &Option<Arc<dyn Buffer>>,
+        input_sender: &Sender<(MessageBatchRef, Arc<dyn Ack>)>,
+    ) -> Result<(), Error> {
+        if let Some(buffer) = buffer_option {
+            buffer.write(msg, ack).await
+        } else {
+            input_sender
+                .send_async((msg, ack))
+                .await
+                .map_err(|e| Error::Process(format!("Failed to send input message: {}", e)))
+        }
+    }
+
     async fn do_input(
         cancellation_token: CancellationToken,
         input: Arc<dyn Input>,
         input_sender: Sender<(MessageBatchRef, Arc<dyn Ack>)>,
         buffer_option: Option<Arc<dyn Buffer>>,
+        wal: Option<Arc<Wal>>,
     ) {
+        // Recovery: replay any WAL entries past the committed cursor before
+        // reading new input. Replayed entries carry a NoopAck source (we replay
+        // from the WAL, not a live source) wrapped in WalAck so the cursor
+        // advances on downstream confirmation.
+        if let Some(wal) = &wal {
+            match wal.read_after_cursor() {
+                Ok(entries) => {
+                    info!("WAL recovery: replaying {} entries", entries.len());
+                    for (seq, msg) in entries {
+                        let ack: Arc<dyn Ack> =
+                            Arc::new(WalAck::new(wal.clone(), seq, Arc::new(NoopAck)));
+                        if let Err(e) =
+                            Self::forward(msg, ack, &buffer_option, &input_sender).await
+                        {
+                            error!("Failed to forward replayed message: {}", e);
+                            break;
+                        }
+                    }
+                }
+                Err(e) => error!("WAL recovery: failed to read WAL: {}", e),
+            }
+        }
+
         loop {
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
@@ -162,16 +209,22 @@ impl Stream {
                 result = input.read() =>{
                     match result {
                     Ok((msg, ack)) => {
-                            if let Some(buffer) = &buffer_option {
-                                if let Err(e) = buffer.write(msg, ack).await {
-                                    error!("Failed to send input message: {}", e);
-                                    break;
+                            let ack: Arc<dyn Ack> = if let Some(wal) = &wal {
+                                match wal.append(&msg).await {
+                                    Ok(seq) => Arc::new(WalAck::new(wal.clone(), seq, ack)),
+                                    Err(e) => {
+                                        error!("Failed to persist message to WAL: {}", e);
+                                        break;
+                                    }
                                 }
-                            } else if let Err(e) = input_sender.send_async((msg, ack)).await {
+                            } else {
+                                ack
+                            };
+
+                            if let Err(e) = Self::forward(msg, ack, &buffer_option, &input_sender).await {
                                 error!("Failed to send input message: {}", e);
                                 break;
                             }
-
                     }
                     Err(e) => {
                         match e {
@@ -300,7 +353,9 @@ impl Stream {
                 }
                 Ok(ProcessResult::None) => {
                     // Message filtered out, just ACK
-                    ack.ack().await;
+                    if let Err(e) = ack.ack().await {
+                        error!("Failed to ack filtered message: {}", e);
+                    }
                 }
                 Err(e) => {
                     if let Err(e) = output_sender
@@ -364,12 +419,16 @@ impl Stream {
         match data {
             ProcessorData::Err(msg, e) => match err_output {
                 None => {
-                    ack.ack().await;
+                    if let Err(err) = ack.ack().await {
+                        error!("Failed to ack errored message: {}", err);
+                    }
                     error!("{e}");
                 }
                 Some(err_output) => match err_output.write(msg).await {
                     Ok(_) => {
-                        ack.ack().await;
+                        if let Err(err) = ack.ack().await {
+                            error!("Failed to ack errored message: {}", err);
+                        }
                     }
                     Err(e) => {
                         error!("{}", e);
@@ -391,7 +450,9 @@ impl Stream {
                 }
 
                 if success_cnt >= size {
-                    ack.ack().await;
+                    if let Err(e) = ack.ack().await {
+                        error!("Failed to ack message: {}", e);
+                    }
                 }
             }
         }
@@ -445,6 +506,7 @@ pub struct StreamConfig {
     pub output: crate::output::OutputConfig,
     pub error_output: Option<crate::output::OutputConfig>,
     pub buffer: Option<crate::buffer::BufferConfig>,
+    pub durability: Option<WalConfig>,
     pub temporary: Option<Vec<crate::temporary::TemporaryConfig>>,
 }
 
@@ -479,6 +541,17 @@ impl StreamConfig {
         } else {
             None
         };
+        // Open the durable ingest WAL only when a `durability:` section is
+        // present and enabled. Absent or disabled → today's in-memory behavior.
+        let wal = if let Some(wal_config) = &self.durability {
+            if wal_config.enabled {
+                Some(Wal::open(wal_config)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         Ok(Stream::new(
             input,
@@ -486,6 +559,7 @@ impl StreamConfig {
             output,
             error_output,
             buffer,
+            wal,
             resource,
             thread_num,
         ))

--- a/crates/arkflow-core/src/wal/mod.rs
+++ b/crates/arkflow-core/src/wal/mod.rs
@@ -1,0 +1,671 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Write-ahead log (WAL) for durable input ingestion.
+//!
+//! Each message read from an input is persisted (`append`) and assigned a
+//! monotonically increasing sequence number before it enters the pipeline.
+//! The committed cursor is advanced (`advance`) only after the downstream
+//! output confirms the write, so a crash between `append` and `advance` leaves
+//! the entry in the WAL and it is replayed on recovery (`read_after_cursor`).
+//!
+//! Storage is an embedded `redb` database. Per-entry writes commit (and fsync)
+//! a transaction per append. `group-commit` and `periodic` policies coalesce
+//! concurrent appends into shared transactions to amortize the fsync cost, at
+//! the price of a small loss window if the process crashes mid-flush.
+
+use crate::{Error, MessageBatch, MessageBatchRef};
+use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::arrow::record_batch::RecordBatch;
+use redb::{Database, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Table mapping sequence number → serialized message.
+const ENTRIES: TableDefinition<u64, &[u8]> = TableDefinition::new("entries");
+/// Single-row metadata table.
+const META: TableDefinition<&str, u64> = TableDefinition::new("meta");
+/// Meta key holding the highest fully acknowledged sequence (the watermark).
+const CURSOR_KEY: &str = "cursor";
+
+/// Sync (fsync) policy for appends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncPolicy {
+    /// Commit (fsync) a transaction on every append. Fully durable; slowest.
+    PerEntry,
+    /// Coalesce concurrent appends into shared transactions flushed as soon as
+    /// pending data is available.
+    GroupCommit,
+    /// Flush pending appends on a fixed interval.
+    Periodic(Duration),
+}
+
+impl Default for SyncPolicy {
+    fn default() -> Self {
+        SyncPolicy::GroupCommit
+    }
+}
+
+/// Configuration for a durable ingest WAL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalConfig {
+    /// Whether durability is active for the stream. Defaults to `true` so that
+    /// adding a `durability:` section enables it; set `false` to disable
+    /// without removing the section. A stream with no `durability:` section at
+    /// all is not durable (today's in-memory behavior).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Directory in which to store the WAL database file.
+    pub path: String,
+    #[serde(default)]
+    pub sync: SyncPolicy,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// A durable write-ahead log for input messages.
+pub struct Wal {
+    db: Database,
+    /// Next sequence number to assign. Append is single-threaded (the input
+    /// worker), but an atomic keeps it race-free regardless.
+    next_seq: AtomicU64,
+    policy: SyncPolicy,
+    // --- staging for group-commit / periodic ---
+    pending: Mutex<Vec<(u64, Vec<u8>)>>,
+    pending_notify: Notify,
+    close: CancellationToken,
+    flusher: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl Wal {
+    /// Open (or create) a WAL database inside `config.path`.
+    pub fn open(config: &WalConfig) -> Result<Arc<Self>, Error> {
+        std::fs::create_dir_all(&config.path).map_err(|e| {
+            Error::Process(format!("Failed to create WAL directory: {}", e))
+        })?;
+        let db_path = Path::new(&config.path).join("wal.redb");
+        let db = Database::create(&db_path)
+            .map_err(|e| Error::Process(format!("Failed to open WAL database: {}", e)))?;
+
+        // Derive next_seq from existing data (max key + 1, or 1 if empty).
+        let next_seq = {
+            let tx = db
+                .begin_read()
+                .map_err(|e| Error::Process(format!("WAL read failed: {}", e)))?;
+            tx.open_table(ENTRIES)
+                .ok()
+                .and_then(|t| t.last().ok().flatten().map(|(k, _)| k.value()))
+                .map(|m| m + 1)
+                .unwrap_or(1)
+        };
+
+        let wal = Arc::new(Self {
+            db,
+            next_seq: AtomicU64::new(next_seq),
+            policy: config.sync.clone(),
+            pending: Mutex::new(Vec::new()),
+            pending_notify: Notify::new(),
+            close: CancellationToken::new(),
+            flusher: Mutex::new(None),
+        });
+
+        match &wal.policy {
+            SyncPolicy::PerEntry => {}
+            SyncPolicy::GroupCommit | SyncPolicy::Periodic(_) => {
+                let handle = Self::spawn_flusher(wal.clone());
+                *wal.flusher.try_lock().unwrap() = Some(handle);
+            }
+        }
+
+        Ok(wal)
+    }
+
+    fn spawn_flusher(wal: Arc<Wal>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let interval = match &wal.policy {
+                SyncPolicy::Periodic(d) => Some(*d),
+                _ => None,
+            };
+            loop {
+                let wait = async {
+                    if let Some(d) = interval {
+                        tokio::time::sleep(d).await;
+                    } else {
+                        wal.pending_notify.notified().await;
+                    }
+                };
+                tokio::select! {
+                    biased;
+                    _ = wal.close.cancelled() => {
+                        let _ = wal.flush_pending().await;
+                        break;
+                    }
+                    _ = wait => {
+                        let _ = wal.flush_pending().await;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Persist a message and return its assigned sequence number.
+    ///
+    /// `per-entry` commits (fsyncs) before returning — fully durable. `group-
+    /// commit` and `periodic` stage the entry and return immediately; the
+    /// background flusher commits batches to amortize the fsync cost. Under
+    /// those two policies a crash before the next flush loses staged entries
+    /// (the documented small loss window) — pick `per-entry` when every entry
+    /// must survive a crash regardless of timing.
+    pub async fn append(&self, msg: &MessageBatchRef) -> Result<u64, Error> {
+        let seq = self.next_seq.fetch_add(1, Ordering::AcqRel);
+        let bytes = serialize(msg)?;
+
+        match &self.policy {
+            SyncPolicy::PerEntry => {
+                self.commit_entry(seq, &bytes)?;
+            }
+            SyncPolicy::GroupCommit | SyncPolicy::Periodic(_) => {
+                self.pending.lock().await.push((seq, bytes));
+                self.pending_notify.notify_one();
+            }
+        }
+        Ok(seq)
+    }
+
+    /// Advance the committed cursor to `seq` (monotonic). Called by the ack
+    /// path only after the downstream output confirms the write.
+    pub fn advance(&self, seq: u64) -> Result<(), Error> {
+        let tx = self
+            .db
+            .begin_write()
+            .map_err(|e| Error::Process(format!("WAL write failed: {}", e)))?;
+        {
+            let mut meta = tx
+                .open_table(META)
+                .map_err(|e| Error::Process(format!("WAL meta open failed: {}", e)))?;
+            let current = meta
+                .get(CURSOR_KEY)
+                .map_err(|e| Error::Process(format!("WAL meta read failed: {}", e)))?
+                .map(|g| g.value())
+                .unwrap_or(0);
+            if seq > current {
+                meta.insert(CURSOR_KEY, seq)
+                    .map_err(|e| Error::Process(format!("WAL meta write failed: {}", e)))?;
+            }
+        }
+        tx.commit()
+            .map_err(|e| Error::Process(format!("WAL commit failed: {}", e)))?;
+        Ok(())
+    }
+
+    /// Read all entries with sequence strictly greater than the committed
+    /// cursor, in ascending order. Used by recovery replay.
+    pub fn read_after_cursor(&self) -> Result<Vec<(u64, MessageBatchRef)>, Error> {
+        let tx = self
+            .db
+            .begin_read()
+            .map_err(|e| Error::Process(format!("WAL read failed: {}", e)))?;
+        let cursor = tx
+            .open_table(META)
+            .ok()
+            .and_then(|t| t.get(CURSOR_KEY).ok().flatten().map(|g| g.value()))
+            .unwrap_or(0);
+        let Some(entries) = tx.open_table(ENTRIES).ok() else {
+            return Ok(Vec::new());
+        };
+
+        let mut out = Vec::new();
+        let range = entries
+            .iter()
+            .map_err(|e| Error::Process(format!("WAL iter failed: {}", e)))?;
+        for item in range {
+            let (k, v) = item.map_err(|e| Error::Process(format!("WAL iter failed: {}", e)))?;
+            let seq = k.value();
+            if seq <= cursor {
+                continue;
+            }
+            let msg = Arc::new(deserialize(v.value())?);
+            out.push((seq, msg));
+        }
+        Ok(out)
+    }
+
+    /// Current committed watermark (highest acked sequence, 0 if none).
+    pub fn cursor(&self) -> u64 {
+        self.db
+            .begin_read()
+            .ok()
+            .and_then(|tx| {
+                tx.open_table(META)
+                    .ok()
+                    .and_then(|t| t.get(CURSOR_KEY).ok().flatten().map(|g| g.value()))
+            })
+            .unwrap_or(0)
+    }
+
+    fn commit_entry(&self, seq: u64, bytes: &[u8]) -> Result<(), Error> {
+        let tx = self
+            .db
+            .begin_write()
+            .map_err(|e| Error::Process(format!("WAL write failed: {}", e)))?;
+        {
+            let mut table = tx
+                .open_table(ENTRIES)
+                .map_err(|e| Error::Process(format!("WAL entries open failed: {}", e)))?;
+            table
+                .insert(seq, bytes)
+                .map_err(|e| Error::Process(format!("WAL insert failed: {}", e)))?;
+        }
+        tx.commit()
+            .map_err(|e| Error::Process(format!("WAL commit failed: {}", e)))?;
+        Ok(())
+    }
+
+    async fn flush_pending(&self) -> Result<(), Error> {
+        let batch: Vec<(u64, Vec<u8>)> = {
+            let mut p = self.pending.lock().await;
+            if p.is_empty() {
+                return Ok(());
+            }
+            std::mem::take(p.as_mut())
+        };
+        let tx = self
+            .db
+            .begin_write()
+            .map_err(|e| Error::Process(format!("WAL write failed: {}", e)))?;
+        {
+            let mut table = tx
+                .open_table(ENTRIES)
+                .map_err(|e| Error::Process(format!("WAL entries open failed: {}", e)))?;
+            for (seq, bytes) in &batch {
+                table
+                    .insert(*seq, bytes.as_slice())
+                    .map_err(|e| Error::Process(format!("WAL insert failed: {}", e)))?;
+            }
+        }
+        tx.commit()
+            .map_err(|e| Error::Process(format!("WAL commit failed: {}", e)))?;
+        Ok(())
+    }
+
+    /// Flush any staged appends and stop the background flusher. After this
+    /// returns the flusher task has exited, so dropping the last `Arc<Wal>`
+    /// closes the underlying database.
+    pub async fn close(&self) -> Result<(), Error> {
+        self.close.cancel();
+        if let Some(handle) = self.flusher.lock().await.take() {
+            let _ = handle.await;
+        }
+        // Best-effort final flush (no-op for per-entry; pending already drained
+        // by the flusher's shutdown branch otherwise).
+        let _ = self.flush_pending().await;
+        Ok(())
+    }
+}
+
+/// Acknowledgement decorator that advances the WAL cursor before delegating to
+/// the source-side ack. Wired into the stream so the durable cursor only moves
+/// past a message once the downstream output confirms the write.
+pub struct WalAck {
+    wal: Arc<Wal>,
+    seq: u64,
+    inner: Arc<dyn crate::input::Ack>,
+}
+
+impl WalAck {
+    pub fn new(wal: Arc<Wal>, seq: u64, inner: Arc<dyn crate::input::Ack>) -> Self {
+        Self { wal, seq, inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::input::Ack for WalAck {
+    async fn ack(&self) -> Result<(), Error> {
+        // Advance the durable cursor first (so the entry is reclaimable on
+        // restart), then commit the source. If the source ack fails after the
+        // cursor advanced, the source re-delivers — at-least-once, not loss.
+        self.wal.advance(self.seq)?;
+        self.inner.ack().await?;
+        Ok(())
+    }
+}
+
+// ---------- serialization ----------
+
+/// Serialize a `MessageBatch` to bytes: a length-prefixed optional input name
+/// followed by the Arrow IPC stream of the record batch (which preserves the
+/// schema, data, and `__meta_*` metadata columns).
+fn serialize(msg: &MessageBatch) -> Result<Vec<u8>, Error> {
+    let record: &RecordBatch = msg.deref();
+    let input_name = msg.get_input_name();
+
+    let mut out = Vec::new();
+    match &input_name {
+        Some(name) => {
+            let len = u32::try_from(name.len())
+                .map_err(|_| Error::Process("input name too long".into()))?;
+            out.extend_from_slice(&len.to_be_bytes());
+            out.extend_from_slice(name.as_bytes());
+        }
+        None => out.extend_from_slice(&0u32.to_be_bytes()),
+    }
+
+    let mut writer =
+        StreamWriter::try_new(&mut out, record.schema().as_ref()).map_err(|e| {
+            Error::Process(format!("Failed to start Arrow IPC writer: {}", e))
+        })?;
+    writer
+        .write(record)
+        .map_err(|e| Error::Process(format!("Failed to write Arrow IPC: {}", e)))?;
+    writer
+        .finish()
+        .map_err(|e| Error::Process(format!("Failed to finish Arrow IPC: {}", e)))?;
+    Ok(out)
+}
+
+/// Deserialize bytes produced by [`serialize`] back into a `MessageBatch`.
+fn deserialize(bytes: &[u8]) -> Result<MessageBatch, Error> {
+    use std::io::{Cursor, Read};
+
+    let mut cursor = Cursor::new(bytes);
+    let mut len_buf = [0u8; 4];
+    cursor
+        .read_exact(&mut len_buf)
+        .map_err(|e| Error::Process(format!("WAL entry truncated (name len): {}", e)))?;
+    let name_len = u32::from_be_bytes(len_buf) as usize;
+    let input_name = if name_len > 0 {
+        let mut nb = vec![0u8; name_len];
+        cursor
+            .read_exact(&mut nb)
+            .map_err(|e| Error::Process(format!("WAL entry truncated (name): {}", e)))?;
+        Some(
+            String::from_utf8(nb)
+                .map_err(|e| Error::Process(format!("WAL entry has invalid utf8 name: {}", e)))?,
+        )
+    } else {
+        None
+    };
+
+    let mut reader = StreamReader::try_new(cursor, None)
+        .map_err(|e| Error::Process(format!("Failed to start Arrow IPC reader: {}", e)))?;
+    let record_batch = reader
+        .next()
+        .ok_or_else(|| Error::Process("WAL entry has no record batch".into()))?
+        .map_err(|e| Error::Process(format!("Failed to read Arrow IPC: {}", e)))?;
+
+    let mut mb = MessageBatch::new_arrow(record_batch);
+    mb.set_input_name(input_name);
+    Ok(mb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::{Ack, NoopAck};
+    use datafusion::arrow::array::{Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc as StdArc;
+
+    fn sample_batch(input_name: Option<&str>) -> MessageBatch {
+        let schema = StdArc::new(Schema::new(vec![
+            Field::new("data", DataType::Utf8, false),
+            Field::new("__meta_offset", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                StdArc::new(StringArray::from(vec![Some("hello"), Some("world")])),
+                StdArc::new(Int64Array::from(vec![Some(10), Some(20)])),
+            ],
+        )
+        .unwrap();
+        let mut mb = MessageBatch::new_arrow(batch);
+        mb.set_input_name(input_name.map(|s| s.to_string()));
+        mb
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        static C: AtomicU64 = AtomicU64::new(0);
+        let n = C.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("arkflow-wal-test-{}-{}", std::process::id(), n));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn roundtrip_preserves_schema_data_and_metadata() {
+        let mb = sample_batch(Some("kafka"));
+        let bytes = serialize(&mb).unwrap();
+        let back = deserialize(&bytes).unwrap();
+        assert_eq!(back.get_input_name().as_deref(), Some("kafka"));
+        let rb_in: &RecordBatch = mb.deref();
+        let rb_out: &RecordBatch = back.deref();
+        assert_eq!(rb_in.schema(), rb_out.schema());
+        assert_eq!(rb_in.num_rows(), rb_out.num_rows());
+        assert_eq!(
+            rb_out
+                .column_by_name("__meta_offset")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(1),
+            20
+        );
+    }
+
+    #[tokio::test]
+    async fn per_entry_write_read_advance_and_reopen() {
+        let dir = tempdir();
+        let cfg = WalConfig {
+            enabled: true,
+            path: dir.to_string_lossy().to_string(),
+            sync: SyncPolicy::PerEntry,
+        };
+        let wal = Wal::open(&cfg).unwrap();
+
+        let seqs = [
+            wal.append(&StdArc::new(sample_batch(None))).await.unwrap(),
+            wal.append(&StdArc::new(sample_batch(None))).await.unwrap(),
+            wal.append(&StdArc::new(sample_batch(None))).await.unwrap(),
+        ];
+        assert_eq!(seqs, [1, 2, 3]);
+
+        // Nothing acked yet: all three are after the cursor.
+        let pending = wal.read_after_cursor().unwrap();
+        assert_eq!(pending.len(), 3);
+
+        // Ack the first two in order; the third remains pending.
+        wal.advance(1).unwrap();
+        wal.advance(2).unwrap();
+        assert_eq!(wal.cursor(), 2);
+        let pending = wal.read_after_cursor().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, 3);
+
+        // Reopen (simulate restart): next_seq continues, cursor persists.
+        wal.close().await.unwrap();
+        drop(wal);
+        let wal2 = Wal::open(&cfg).unwrap();
+        let pending = wal2.read_after_cursor().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, 3);
+        // New appends continue from seq 4, not colliding.
+        let s4 = wal2
+            .append(&StdArc::new(sample_batch(None)))
+            .await
+            .unwrap();
+        assert_eq!(s4, 4);
+    }
+
+    #[tokio::test]
+    async fn group_commit_flushes_on_close() {
+        let dir = tempdir();
+        let cfg = WalConfig {
+            enabled: true,
+            path: dir.to_string_lossy().to_string(),
+            sync: SyncPolicy::GroupCommit,
+        };
+        let wal = Wal::open(&cfg).unwrap();
+        // group-commit stages appends; they are flushed by the background
+        // flusher and on close. After close + reopen they must all be present.
+        let s1 = wal.append(&StdArc::new(sample_batch(None))).await.unwrap();
+        let s2 = wal.append(&StdArc::new(sample_batch(None))).await.unwrap();
+        wal.close().await.unwrap();
+        drop(wal);
+        let wal2 = Wal::open(&cfg).unwrap();
+        let seqs: Vec<u64> = wal2
+            .read_after_cursor()
+            .unwrap()
+            .iter()
+            .map(|(s, _)| *s)
+            .collect();
+        assert!(seqs.contains(&s1));
+        assert!(seqs.contains(&s2));
+    }
+
+    #[tokio::test]
+    async fn corrupted_store_surfaces_error() {
+        let dir = tempdir();
+        let cfg = WalConfig {
+            enabled: true,
+            path: dir.to_string_lossy().to_string(),
+            sync: SyncPolicy::PerEntry,
+        };
+        let wal = Wal::open(&cfg).unwrap();
+        wal.append(&StdArc::new(sample_batch(None)))
+            .await
+            .unwrap();
+        wal.close().await.unwrap();
+        drop(wal);
+        // Corrupt the database header with garbage bytes (a torn header must
+        // not silently produce a valid, empty WAL — it must surface an error).
+        use std::io::Write;
+        let db_path = dir.join("wal.redb");
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&db_path)
+            .unwrap();
+        f.write_all(&[0xFFu8; 256]).unwrap();
+        f.flush().unwrap();
+        drop(f);
+        let result = Wal::open(&cfg);
+        assert!(
+            result.is_err(),
+            "opening a corrupted WAL must surface an error"
+        );
+    }
+
+    /// End-to-end crash-recovery contract (task 6.4): a message ingested but
+    /// not yet acknowledged must survive a crash and be replayed on restart
+    /// (no loss); the replay IS the at-least-once duplicate. Once the
+    /// downstream confirms, the cursor advances and a further restart replays
+    /// nothing.
+    #[tokio::test]
+    async fn crash_recovery_replays_unacked_then_advances_on_ack() {
+        let dir = tempdir();
+        let cfg = WalConfig {
+            enabled: true,
+            path: dir.to_string_lossy().to_string(),
+            sync: SyncPolicy::PerEntry,
+        };
+
+        // Phase 1: ingest a message, then "crash" before acknowledging it.
+        let wal = Wal::open(&cfg).unwrap();
+        let seq = wal
+            .append(&StdArc::new(sample_batch(Some("http"))))
+            .await
+            .unwrap();
+        assert_eq!(seq, 1);
+        // No advance — simulate a crash before the downstream output confirmed.
+        wal.close().await.unwrap();
+        drop(wal);
+
+        // Phase 2: restart. Recovery must replay the unacked message (no loss).
+        let wal2 = Wal::open(&cfg).unwrap();
+        let replayed = wal2.read_after_cursor().unwrap();
+        assert_eq!(
+            replayed.len(),
+            1,
+            "unacked message must be replayed (no loss)"
+        );
+        assert_eq!(replayed[0].0, seq);
+        assert_eq!(replayed[0].1.get_input_name().as_deref(), Some("http"));
+
+        // Phase 3: downstream confirms → WalAck advances the cursor first, then
+        // the (noop) source ack. The replay above is the at-least-once duplicate.
+        let ack: StdArc<dyn Ack> = StdArc::new(WalAck::new(
+            wal2.clone(),
+            replayed[0].0,
+            StdArc::new(NoopAck),
+        ));
+        ack.ack().await.unwrap();
+        assert_eq!(wal2.cursor(), seq);
+        drop(ack); // release the WalAck's Arc<Wal> so the database can close
+
+        // Phase 4: a further restart replays nothing — fully acknowledged.
+        wal2.close().await.unwrap();
+        drop(wal2);
+        let wal3 = Wal::open(&cfg).unwrap();
+        assert!(wal3.read_after_cursor().unwrap().is_empty());
+    }
+
+    /// Throughput benchmark per sync policy (task 5.3). Ignored by default;
+    /// run with `cargo test -p arkflow-core --lib wal::tests::bench_append_throughput --release -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn bench_append_throughput() {
+        let n = 5_000u32;
+        for (name, policy) in [
+            ("per_entry", SyncPolicy::PerEntry),
+            ("group_commit", SyncPolicy::GroupCommit),
+            ("periodic_1ms", SyncPolicy::Periodic(Duration::from_millis(1))),
+        ] {
+            let dir = tempdir();
+            let cfg = WalConfig {
+                enabled: true,
+                path: dir.to_string_lossy().to_string(),
+                sync: policy,
+            };
+            let wal = Wal::open(&cfg).unwrap();
+            let msg = StdArc::new(sample_batch(None));
+            let start = std::time::Instant::now();
+            for _ in 0..n {
+                wal.append(&msg).await.unwrap();
+            }
+            wal.close().await.unwrap();
+            let elapsed = start.elapsed();
+            let per = elapsed / n;
+            println!(
+                "bench {}: {} appends in {:?} ({:.2} us/append, {:.0} appends/s)",
+                name,
+                n,
+                elapsed,
+                per.as_secs_f64() * 1e6,
+                n as f64 / elapsed.as_secs_f64()
+            );
+        }
+    }
+}

--- a/crates/arkflow-plugin/src/buffer/memory.rs
+++ b/crates/arkflow-plugin/src/buffer/memory.rs
@@ -229,10 +229,11 @@ struct ArrayAck(Vec<Arc<dyn Ack>>);
 #[async_trait]
 impl Ack for ArrayAck {
     /// Acknowledges all contained acknowledgments
-    async fn ack(&self) {
+    async fn ack(&self) -> Result<(), Error> {
         for ack in self.0.iter() {
-            ack.ack().await;
+            ack.ack().await?;
         }
+        Ok(())
     }
 }
 

--- a/crates/arkflow-plugin/src/input/kafka.rs
+++ b/crates/arkflow-plugin/src/input/kafka.rs
@@ -85,11 +85,12 @@ impl KafkaInput {
         let duration = std::time::Duration::from_millis(millis_u64);
         SystemTime::UNIX_EPOCH.checked_add(duration)
     }
-}
 
-#[async_trait]
-impl Input for KafkaInput {
-    async fn connect(&self) -> Result<(), Error> {
+    /// Build the rdkafka `ClientConfig` from the input configuration.
+    ///
+    /// Extracted from `connect()` so the crash-safety settings (notably
+    /// `enable.auto.offset.store=false`) are unit-testable without a broker.
+    fn build_client_config(&self) -> ClientConfig {
         let mut client_config = ClientConfig::new();
 
         // Configure the Kafka server address
@@ -129,6 +130,30 @@ impl Input for KafkaInput {
         } else {
             client_config.set("auto.offset.reset", "earliest");
         }
+
+        // Disable automatic offset storage so offsets are NOT advanced when a
+        // message is merely delivered to the application. With the default
+        // (`enable.auto.offset.store=true`) every `recv()` would store its
+        // offset, and the periodic auto-commit would then commit it to the
+        // broker before the downstream output has confirmed the write — a
+        // crash in between loses the message.
+        //
+        // Disabling it makes `store_offset()` (called in `KafkaAck::ack()`,
+        // which only fires after a successful `output.write()`) the sole way
+        // to advance the offset, giving at-least-once delivery across crashes.
+        // The periodic auto-commit (`enable.auto.commit=true`, the default)
+        // still runs, but it only commits offsets that have been explicitly
+        // stored — i.e. only acked messages.
+        client_config.set("enable.auto.offset.store", "false");
+
+        client_config
+    }
+}
+
+#[async_trait]
+impl Input for KafkaInput {
+    async fn connect(&self) -> Result<(), Error> {
+        let client_config = self.build_client_config();
 
         // Create consumers
         let consumer: StreamConsumer = client_config
@@ -256,14 +281,15 @@ pub struct KafkaAck {
 
 #[async_trait]
 impl Ack for KafkaAck {
-    async fn ack(&self) {
-        // Commit offsets
+    async fn ack(&self) -> Result<(), Error> {
+        // Store the offset so it is committed by the periodic auto-commit.
+        // Only called after the downstream output confirms the write.
         let consumer_mutex_guard = self.consumer.read().await;
         if let Some(v) = &*consumer_mutex_guard {
-            if let Err(e) = v.store_offset(&self.topic, self.partition, self.offset) {
-                tracing::error!("Error committing Kafka offset: {}", e);
-            }
+            v.store_offset(&self.topic, self.partition, self.offset)
+                .map_err(|e| Error::Process(format!("Failed to store Kafka offset: {}", e)))?;
         }
+        Ok(())
     }
 }
 
@@ -364,7 +390,7 @@ mod tests {
         };
 
         // Test acknowledgment, should have no effect since there is no actual consumer
-        ack.ack().await;
+        let _ = ack.ack().await;
         // This test mainly verifies that the ack method does not panic
     }
 
@@ -416,5 +442,98 @@ mod tests {
         ext_meta.insert("topic".to_string(), "test-topic".to_string());
         let result = metadata::with_ext_metadata(batch, &ext_meta);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_kafka_disables_auto_offset_store_for_crash_safety() {
+        // Phase 0 (add-input-durability): at-least-once crash-safety depends on
+        // offsets being stored ONLY inside `KafkaAck::ack()` (which fires after
+        // the downstream output confirms the write), never on `recv()`. Verify
+        // the consumer config disables rdkafka's automatic offset store.
+        let config = KafkaInputConfig {
+            brokers: vec!["localhost:9092".to_string()],
+            topics: vec!["test-topic".to_string()],
+            consumer_group: "test-group".to_string(),
+            client_id: None,
+            start_from_latest: false,
+            fetch_min_bytes: None,
+            fetch_max_bytes: None,
+            fetch_max_partition_bytes: None,
+            fetch_wait_max_ms: None,
+        };
+        let input = KafkaInput::new(None, config, None).unwrap();
+        let client_config = input.build_client_config();
+        assert_eq!(
+            client_config.get("enable.auto.offset.store"),
+            Some("false"),
+            "auto offset store MUST be disabled so offsets advance only on ack (at-least-once)"
+        );
+    }
+
+    /// Broker-gated integration test (Phase 0, task 1.3): proves a replayable
+    /// source re-delivers an unacknowledged message after a simulated crash,
+    /// because `enable.auto.offset.store=false` means the offset only advances
+    /// inside `KafkaAck::ack()` (which never fires below).
+    ///
+    /// Skipped unless `ARKFLOW_KAFKA_BROKER` is set. Run with:
+    /// `cargo test -p arkflow-plugin --lib input::kafka::tests::kafka_redelivers_unacked_after_restart -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore]
+    async fn kafka_redelivers_unacked_after_restart() {
+        use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+        use std::time::Duration;
+
+        let broker = match std::env::var("ARKFLOW_KAFKA_BROKER") {
+            Ok(b) => b,
+            Err(_) => return, // no broker available — skip
+        };
+        let topic = std::env::var("ARKFLOW_KAFKA_TOPIC")
+            .unwrap_or_else(|_| "arkflow_durability_test".to_string());
+        let group = format!("arkflow-dur-test-{}", std::process::id());
+
+        fn cfg(brokers: &str, topics: &str, group: &str) -> KafkaInputConfig {
+            KafkaInputConfig {
+                brokers: vec![brokers.to_string()],
+                topics: vec![topics.to_string()],
+                consumer_group: group.to_string(),
+                client_id: None,
+                start_from_latest: false,
+                fetch_min_bytes: None,
+                fetch_max_bytes: None,
+                fetch_max_partition_bytes: None,
+                fetch_wait_max_ms: None,
+            }
+        }
+
+        // Produce one message.
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", &broker)
+            .set("message.timeout.ms", "5000")
+            .create()
+            .expect("producer create");
+        let payload_bytes = b"ping".to_vec();
+producer
+            .send(
+                FutureRecord::<String, Vec<u8>>::to(&topic).payload(&payload_bytes),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("produce");
+        producer.flush(Duration::from_secs(10)).expect("flush");
+
+        // First consumer: read the message, do NOT ack (simulate a crash before
+        // the downstream output confirms). The offset is NOT stored.
+        let input = KafkaInput::new(None, cfg(&broker, &topic, &group), None).unwrap();
+        input.connect().await.unwrap();
+        let (_msg, _ack) = input.read().await.expect("first read must succeed");
+        drop(input); // crash without acking
+
+        // Reconnect with the same group: the message must be re-delivered.
+        let input2 = KafkaInput::new(None, cfg(&broker, &topic, &group), None).unwrap();
+        input2.connect().await.unwrap();
+        let (_msg2, _ack2) = input2
+            .read()
+            .await
+            .expect("unacked message must be re-delivered after restart (no loss)");
     }
 }

--- a/crates/arkflow-plugin/src/input/memory.rs
+++ b/crates/arkflow-plugin/src/input/memory.rs
@@ -171,7 +171,7 @@ mod tests {
             String::from_utf8_lossy(result.get(0).unwrap()),
             "test message"
         );
-        ack.ack().await;
+        let _ = ack.ack().await;
     }
 
     #[tokio::test]

--- a/crates/arkflow-plugin/src/input/mqtt.rs
+++ b/crates/arkflow-plugin/src/input/mqtt.rs
@@ -245,13 +245,15 @@ struct MqttAck {
 }
 #[async_trait]
 impl Ack for MqttAck {
-    async fn ack(&self) {
+    async fn ack(&self) -> Result<(), Error> {
         let mutex_guard = self.client.lock().await;
         if let Some(client) = &*mutex_guard {
-            if let Err(e) = client.ack(&self.publish).await {
-                error!("{}", e);
-            }
+            client
+                .ack(&self.publish)
+                .await
+                .map_err(|e| Error::Process(format!("Failed to ack MQTT message: {}", e)))?;
         }
+        Ok(())
     }
 }
 

--- a/crates/arkflow-plugin/src/input/nats.rs
+++ b/crates/arkflow-plugin/src/input/nats.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, warn};
+use tracing::error;
 
 /// NATS input configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -450,16 +450,18 @@ enum NatsAck {
 
 #[async_trait]
 impl Ack for NatsAck {
-    async fn ack(&self) {
+    async fn ack(&self) -> Result<(), Error> {
         match self {
             NatsAck::Regular => {
                 // For regular NATS messages, there's no explicit acknowledgment
+                Ok(())
             }
             NatsAck::JetStream { message } => {
                 // Acknowledge JetStream message
-                if let Err(e) = message.ack().await {
-                    warn!("Failed to acknowledge JetStream message: {}", e);
-                }
+                message
+                    .ack()
+                    .await
+                    .map_err(|e| Error::Process(format!("Failed to ack JetStream message: {}", e)))
             }
         }
     }

--- a/crates/arkflow-plugin/src/input/pulsar.rs
+++ b/crates/arkflow-plugin/src/input/pulsar.rs
@@ -322,15 +322,15 @@ impl PulsarAck {
 
 #[async_trait]
 impl Ack for PulsarAck {
-    async fn ack(&self) {
+    async fn ack(&self) -> Result<(), Error> {
         if let (Some(consumer), Some(message)) = (&self.consumer, &self.message) {
             let mut consumer_guard = consumer.lock().await;
-            if let Err(e) = consumer_guard.ack(message).await {
-                error!("Failed to acknowledge Pulsar message: {}", e);
-            } else {
-                tracing::debug!("Successfully acknowledged Pulsar message");
-            }
+            consumer_guard
+                .ack(message)
+                .await
+                .map_err(|e| Error::Process(format!("Failed to ack Pulsar message: {}", e)))?;
         }
+        Ok(())
     }
 }
 

--- a/docs/docs/components/0-inputs/delivery-semantics.md
+++ b/docs/docs/components/0-inputs/delivery-semantics.md
@@ -1,0 +1,64 @@
+# Input Delivery Semantics
+
+How ArkFlow handles messages across crashes depends on whether an input can
+**re-deliver** a message that has not yet been acknowledged. This page classifies
+every input and explains the at-least-once delivery contract.
+
+## Background: the ack-after-output rule
+
+For every input, the source is only acknowledged **after** the downstream output
+confirms the write. This means a crash between reading a message and writing it
+out does not silently drop the message — *provided the source can re-deliver it*.
+
+## Replayable vs non-replayable inputs
+
+A **replayable** source can re-deliver an unacknowledged message after a crash
+(typically because it retains the message and tracks an offset/position that is
+only advanced on ack). A **non-replayable** source discards a message as soon as
+it is read, so a crash after read and before output loses it unless the message
+is persisted locally first.
+
+| Input | Replayable? | Source-side ack |
+|-------|-------------|-----------------|
+| **Kafka** | Yes | `store_offset` on ack only; `enable.auto.offset.store=false` |
+| **MQTT** | Yes (QoS ≥ 1) | manual ack (`set_manual_acks(true)`); default QoS 1 |
+| **NATS (JetStream)** | Yes | `message.ack()` on ack only |
+| **Pulsar** | Yes | `consumer.ack()` on ack only |
+| **Redis (Streams)** | Yes (with consumer groups) | depends on configuration |
+| **SQL** | Partial (incremental query) | via incremental cursor |
+| **HTTP (server)** | **No** (webhook) | none — fire-and-forget |
+| **HTTP (client poll)** | **No** | none |
+| **File** | **No** (read-once stream) | none |
+| **Generate** | **No** | none |
+| **Modbus** | **No** | none |
+| **Memory** | **No** | none |
+| **WebSocket** | **No** | none |
+
+## What this means for durability
+
+- **Replayable sources** are crash-safe today (Phase 0 of `add-input-durability`):
+  the source only commits/acks on ack, so on restart it re-delivers any
+  in-flight messages that were never confirmed. No local persistence is needed.
+  The Kafka input, for example, sets `enable.auto.offset.store=false` so the
+  offset advances only inside `ack()`.
+- **Non-replayable sources** need a durable write-ahead log (WAL) at the input
+  boundary so the message body survives a crash and can be replayed on restart.
+  This is Phase 1 of `add-input-durability` (the per-stream `durability:` option).
+
+## At-least-once contract
+
+ArkFlow provides **at-least-once** delivery. After a crash and recovery,
+in-flight messages MAY be delivered more than once. Outputs MUST tolerate
+duplicates (for example, UPSERT-style SQL/InfluxDB sinks are naturally
+idempotent; HTTP and Kafka outputs should expect possible duplicates).
+
+Exactly-once delivery is not provided.
+
+## Single-node boundary
+
+The durable WAL lives on the local disk of the node running the stream. It
+protects against **process crashes** (kill, panic, power loss to the process),
+not against the loss of the node itself (disk failure, host termination). High
+availability across nodes (replicated WAL / consensus) is out of scope. For
+HA-grade durability, run on replicated storage or front the stream with a
+durable, replayable source (e.g. Kafka).

--- a/examples/durability_example.yaml
+++ b/examples/durability_example.yaml
@@ -1,0 +1,43 @@
+# Durability (crash recovery) example.
+#
+# Enabling `durability:` on a stream persists every message read from the input
+# to a write-ahead log (WAL) before it enters the pipeline. The source is only
+# acknowledged after the downstream output confirms the write, so a crash between
+# read and output does not lose data: on restart, any unacknowledged messages are
+# replayed from the WAL.
+#
+# This is most valuable for NON-replayable sources (HTTP webhooks, Modbus,
+# Generate, files), which cannot re-deliver a message after a crash. For
+# replayable sources (Kafka/MQTT/NATS/Pulsar) the source itself can re-deliver,
+# but the WAL still guarantees no loss regardless of source settings.
+#
+# Semantics: at-least-once. After a crash, in-flight messages MAY be delivered
+# more than once, so outputs should tolerate duplicates (e.g. UPSERT sinks).
+# Single-node only: this survives process crashes, not the loss of the node
+# (the WAL lives on local disk).
+
+logging:
+  level: info
+
+streams:
+  - input:
+      type: "generate"
+      context: '{ "value": 10, "sensor": "temp_1" }'
+      interval: 1ns
+      batch_size: 1
+      count: 1000
+
+    # Durable ingest: persist every message to ./data/wal before processing.
+    durability:
+      enabled: true
+      path: "./data/wal"
+      sync: "group_commit"   # per_entry | group_commit | periodic
+
+    pipeline:
+      thread_num: 4
+      processors:
+        - type: "json_to_arrow"
+        - type: "arrow_to_json"
+
+    output:
+      type: "stdout"

--- a/openspec/changes/archive/2026-07-26-add-input-durability/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/archive/2026-07-26-add-input-durability/design.md
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/design.md
@@ -1,0 +1,147 @@
+## Context
+
+Today every message in flight in ArkFlow lives only in memory:
+
+```
+input.read() → [flume channel] → [optional in-memory/window buffer] → processor → [flume channel] → output.write() → ack.ack()
+```
+
+The `Ack` plumbing is already correct in shape — `ack.ack()` fires only after a successful `output.write()` (`stream/mod.rs`). But nothing between `input.read()` and `ack.ack()` is durable:
+
+- `memory` / `tumbling_window` / `sliding_window` / `session_window` / `join` buffers are all in-memory `VecDeque`s.
+- The two flume channels in `Stream::run` are in-memory.
+- `Ack::ack()` returns `()` — failures are invisible.
+
+Source-side acks are only partially crash-safe:
+- **Kafka**: `store_offset` on ack (`input/kafka.rs`); crash-safe only if `enable.auto.commit=false`.
+- **MQTT / NATS / Pulsar**: manual ack on ack(); crash-safe if not auto-acked.
+- **HTTP / File / Generate / Modbus / Redis / SQL / WebSocket**: `NoopAck` — non-replayable, no durability whatsoever.
+
+So the crash-loss window is the entire gap between `input.read()` and `ack.ack()`, and it is fatal for non-replayable sources.
+
+## Goals / Non-Goals
+
+**Goals:**
+- No data entering from any input is lost across a process crash (at-least-once).
+- Crash recovery: on restart, replay any WAL entries past the committed cursor before streams resume.
+- Durability is **orthogonal** to windowing — a stream can have both a window buffer and durable ingest.
+- Reuse the existing ack-after-output plumbing; minimize changes to the `Stream` control flow.
+
+**Non-Goals:**
+- Exactly-once semantics (requires transactional/idempotent sinks — separate, much larger effort).
+- Multi-node HA / replicated WAL (single-node crash recovery only).
+- Full-pipeline persistent backbone (durability at every inter-stage hop).
+- State checkpointing for stateful processors (window/join accumulated state).
+- Splitting or restructuring the existing `Buffer` trait.
+
+## Decisions
+
+### D1 — Core shape (UNCHANGED): durability rides the ack path, it is not a buffer type
+
+The WAL persists on `input.read()` and advances its cursor when the downstream ack fires. It reuses the existing "ack-after-output" pipe with no change to the `Stream` control flow. Durability is a property of the ingest boundary, conceptually separate from the windowing buffers (which transform timing, pop-on-read, and are in-memory by design).
+
+```
+input.read() → [ WAL ingest: persist msg+seq, fsync ] → buffer(window) → processor → output → [ commit: advance WAL cursor, then source ack ]
+```
+
+**Alternatives considered:**
+- *Make durability a new `Buffer` type.* Rejected — `buffer.type` is single-select, forcing "window OR durable" to be mutually exclusive, and the Buffer trait semantics (pop-on-read) conflict with ack-tied cursor advancement. Conflating windowing and durability yields a leaky abstraction.
+
+### D2 — BREAKING: `Ack::ack()` becomes fallible
+
+```rust
+// before
+async fn ack(&self);
+// after
+async fn ack(&self) -> Result<(), Error>;
+```
+
+**Why.** A WAL whose cursor-advance / source-commit can fail silently cannot be called crash-safe. Today `ack()` returns `()`, so a disk-full or store error during cursor advance is invisible: either it is swallowed and the source still commits (loss risk on the next crash), or it is withheld but the stream keeps reading until the WAL grows unbounded with no signal. A fallible ack surfaces these errors so the stream can apply backpressure or stop.
+
+**Nuance (honest).** A failed cursor advance is *not* data loss — it is *duplicate* data (the un-advanced entry replays on the next restart), which already falls inside the at-least-once contract. So fallible ack's primary value is **observability + backpressure**, not loss-prevention. It is still required: a silent-failure durability layer is unacceptable, and backpressure on WAL growth is the only thing keeping a cursor-advance failure from becoming an unbounded resource leak.
+
+**Migration.** Every `Ack` implementor must change signature: `KafkaAck`, `MQTT`/`NATS`/`Pulsar` acks, plus `NoopAck` (returns `Ok(())`) and `VecAck` (propagates first error). Every `ack.ack().await` call site in `Stream` (e.g. `do_processor`, `output`) must handle the `Result`.
+
+### D3 — BREAKING: the WAL is a first-class ingest stage owned by `Stream`, not an `Input` decorator
+
+Instead of a `WalInput` wrapping an `Input`, the `Stream` owns the WAL directly. Config gains a top-level per-stream `durability:` section; the `Stream` struct and its run loop gain an explicit ingest stage.
+
+```
+stream:
+  durability:        # NEW
+    enabled: true
+    path: ./data/wal/<stream>
+    sync: group-commit   # per-entry | group-commit | periodic
+    flush_interval: 50ms
+  input: ...
+  pipeline: ...
+  output: ...
+```
+
+**Why.** A decorator was a workaround to avoid touching `Stream`. Owning the WAL in the stream is more honest about what is happening, removes a layer of indirection, and lets recovery be coordinated at the `Engine`/`Stream` level. Notably this does **not** require changing the `Input` trait — the stream takes `(msg, ack)` from `input.read()`, runs it through its WAL, and produces a `WalAck` wrapping the source ack.
+
+### D4 — Storage engine: embedded transactional store (`redb`)
+
+Persist each entry as `(seq → Arrow IPC bytes)`; the committed cursor is the highest contiguous acked `seq`. `redb` is pure-Rust, transactional, and ACID — it handles the durability primitives we do not want to hand-roll.
+
+**Alternatives considered:**
+- *Custom append-only segment log + cursor.* Rejected for v1 — hand-rolling correct durability is a known minefield (fsync the file *and* the directory on create/rename; recover gracefully from a corrupted half-written tail via checksums + length-prefix; durably persist the cursor itself; segment rotation/reclaim). Higher risk, more code, for no v1 benefit.
+- *`sled` / `rocksdb` / SQLite.* Viable; `redb` chosen for the smallest pure-Rust footprint and transactional API that maps cleanly to "advance cursor atomically with reclaim." Open to revisiting (see Open Questions).
+
+### D5 — fsync policy: group-commit by default
+
+Per-entry fsync would cap throughput at single-digit ms latency. Default to **group-commit** on the natural `MessageBatch` granularity; expose `sync` as configurable (`per-entry` | `group-commit` | `periodic`). This is the single real throughput-vs-durability trade-off and is made explicit.
+
+**Semantics** (important):
+- `per-entry` — every `append()` commits a transaction before returning. Fully durable; fsync-bound.
+- `group-commit` and `periodic` — `append()` stages the entry in an in-memory queue and returns immediately (NOT durable yet). A background flusher commits batches (group-commit: as soon as pending is non-empty; periodic: on a fixed interval). A crash before the next flush loses staged entries — the documented **small loss window** in exchange for much higher throughput.
+- This means `group-commit`/`periodic` accept a bounded loss window for speed; `per-entry` accepts the fsync cost for full durability. The tradeoff is real and configurable.
+
+**Measured throughput** (`cargo test -p arkflow-core --release wal::tests::bench_append_throughput -- --ignored`, 5000 sequential appends of a small batch):
+
+| Policy | appends/s | µs/append |
+|---|---|---|
+| `per-entry` | ~184 | ~5445 |
+| `group-commit` | ~19,450 | ~51 |
+| `periodic(1ms)` | ~47,569 | ~21 |
+
+`group-commit` is ~106× faster than `per-entry` by amortizing fsync across staged entries.
+
+### D6 — Semantics: at-least-once, duplicate-tolerance as an output contract
+
+Recovery replays in-flight entries → outputs may receive duplicates. This is stated as a contract: outputs MUST tolerate duplicates (UPSERT-friendly sinks like SQL/InfluxDB are natural; HTTP/Kafka outputs must document possible duplicates). Exactly-once is explicitly a Non-Goal.
+
+### D7 — Phase 1 stores body uniformly for all inputs
+
+Every enabled input persists the full message body, including replayable sources (Kafka/MQTT/...). This accepts a known double-write for replayable sources in exchange for a uniform mental model and fewer edge cases. Per-source optimization (offset-only WAL for replayable sources) is deferred.
+
+### Staged delivery
+
+- **Phase 0 (no breaking changes):** Audit and correct source-side ack gating — Kafka/MQTT/NATS/Pulsar default to manual commit; ack fires only after output success. Alone, this makes replayable-source → durable-output crash-safe *today*.
+- **Phase 1 (the breaking changes):** `WalInput`-free first-class ingest stage (D3), fallible ack (D2), `redb` body WAL (D4/D7), recovery replay, group-commit (D5).
+
+## Risks / Trade-offs
+
+- **fsync throughput cliff** → group-commit default + configurable sync policy (D5). Benchmark before/after.
+- **New dependency (`redb`)** → pure-Rust, transactional; validate its fsync guarantees on the target platforms. Fallback to a custom segment log if unacceptable (D4).
+- **Duplicate delivery after recovery** → documented as the at-least-once contract; outputs MUST be duplicate-tolerant (D6).
+- **WAL unbounded growth on cursor-advance failure** → fallible ack (D2) surfaces the error so the stream can backpressure/stop instead of leaking.
+- **Corrupted WAL tail after mid-write crash** → `redb` transactions handle atomicity; if we ever move to a custom log, checksums + length-prefix on recovery are mandatory.
+- **Single-node boundary** → this design does not survive node loss, only process crash. HA is a Non-Goal.
+- **Behavioral change for existing configs** → durability is opt-in (`enabled: true`); streams without `durability:` keep today's in-memory behavior, so the blast radius is limited to the ack signature break (D2).
+
+## Migration Plan
+
+1. **Phase 0 first** — no public breaks; ship source ack-gating fixes. Safe to release independently.
+2. **D2 (fallible ack)** — update `Ack` trait and all implementors in one coordinated change (core + plugins). Update all `ack.ack().await` call sites in `Stream` to handle `Result`.
+3. **D3 + D4 + D5 + D7** — add the `durability:` config, the stream-owned WAL ingest stage, `redb` persistence, and group-commit.
+4. **Recovery** — Engine startup phase: open WAL, replay entries past the committed cursor into the stream before `run()`.
+5. **Rollback** — durability is opt-in per stream; disabling `durability:` reverts to today's behavior. The only non-opt-out break is the ack signature, which is compile-time (no silent runtime regression).
+
+## Open Questions
+
+- **redb vs alternatives** — final storage-engine call once we validate `redb` fsync behavior and Arrow IPC round-trip cost. (D4)
+- **Default fsync policy** — confirm `group-commit` with a representative flush interval as the shipped default. (D5)
+- **WAL placement** — per-stream subdirectory under a configurable root; naming/clash rules for unnamed streams.
+- **Uniform source classification** — do we need an explicit `replayable: bool` marker on inputs for future offset-only optimization (D7), or infer it? Deferred, but worth reserving.
+- **Recovery ordering vs. temporary storage** — does WAL replay need to coordinate with `temporary` storage connect/ordering in `Stream::run`?

--- a/openspec/changes/archive/2026-07-26-add-input-durability/proposal.md
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+All in-flight data in ArkFlow lives only in memory (flume channels + the in-memory/window buffers). A process crash anywhere between `input.read()` and `ack.ack()` permanently loses data for non-replayable sources (HTTP webhook, Modbus, Generate, file streams), and risks loss even for replayable sources (Kafka/MQTT/NATS/Pulsar) if the source auto-commits before the downstream output confirms. We need durable ingestion plus crash recovery so that **no data entering from any input is lost** across crashes.
+
+## What Changes
+
+- **NEW**: Durable ingest WAL at the stream input boundary — every read message is persisted (body + sequence) and `fsync`'d before it enters the pipeline.
+- **NEW**: Ack-gated durability — the durable WAL cursor advances, and the source is committed, only after the downstream output confirms the write. Reuses the existing "ack-after-output" plumbing.
+- **NEW**: Crash recovery — on startup, the Engine replays any WAL entries past the committed cursor before streams resume.
+- **NEW**: Per-stream `durability:` configuration (storage path, sync policy, retention).
+- **NEW**: At-least-once delivery semantics, documented as an explicit contract (crash recovery may re-deliver in-flight messages; outputs MUST tolerate duplicates).
+- **BREAKING**: `Ack::ack()` becomes fallible — `async fn ack(&self) -> Result<(), Error>` instead of `-> ()`. Required so WAL cursor-advance / source-commit failures are observable and can drive backpressure instead of failing silently.
+- **BREAKING**: The WAL is a first-class ingest stage owned by the `Stream` (new `durability:` config section, changes to the `Stream` struct and its run loop), not an `Input` decorator. Removes a layer of indirection and makes the durability boundary explicit.
+- **Phase 0 (no breaks)**: Audit and correct source-side ack gating — ensure Kafka/MQTT/NATS/Pulsar default to manual commit and ack only after output success. This alone makes replayable-source → durable-output crash-safe today.
+
+## Capabilities
+
+### New Capabilities
+- `message-acknowledgment`: The cross-cutting `Ack` contract — fallible acknowledgement that propagates errors from cursor-advance / source-commit back to the stream.
+- `input-durability`: Durable ingestion (WAL) at the input boundary, ack-gated cursor advancement, and crash-recovery replay. At-least-once semantics.
+
+### Modified Capabilities
+<!-- None — openspec/specs/ is currently empty, so all behavior is captured as new capabilities above. -->
+
+## Impact
+
+- **`arkflow-core`**: `Ack` trait signature change (fallible); `Stream` struct + run loop gain a WAL ingest stage; `StreamConfig` gains a `durability` section; `Engine` gains a startup recovery phase.
+- **`arkflow-plugin`**: Every `Ack` implementor updates to the fallible signature — Kafka, MQTT, NATS, Pulsar inputs (and any `NoopAck`/`VecAck` usages). Output plugins' duplicate-tolerance becomes a documented contract.
+- **Dependencies**: New embedded transactional store (proposed: `redb`) for WAL persistence.
+- **Behavioral**: At-least-once (possible duplicates after recovery); new fsync cost on the ingest hot path (mitigated by group-commit).
+- **Out of scope**: exactly-once semantics, multi-node HA, full-pipeline persistent backbone, state checkpointing for stateful processors.

--- a/openspec/changes/archive/2026-07-26-add-input-durability/specs/input-durability/spec.md
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/specs/input-durability/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Durable ingestion at the input boundary
+When durability is enabled for a stream, every message returned by `input.read()` SHALL be persisted (body + sequence) and durably flushed to the WAL before it enters the pipeline.
+
+#### Scenario: Message is durable before processing
+- **WHEN** an input reads a message on a durability-enabled stream
+- **THEN** the message body and an assigned sequence are written and flushed to the WAL before the message is handed to the buffer/processor
+
+#### Scenario: Crash after read does not lose data
+- **WHEN** the process crashes after `input.read()` returns but before the message is processed or output
+- **THEN** the message is present in the WAL on restart and is replayed
+
+### Requirement: Ack-gated cursor advancement and source commit
+The WAL cursor SHALL advance past a message's sequence, and the source-side acknowledgement SHALL be performed, only after the downstream output confirms the write. The source commit SHALL happen after the WAL cursor advances.
+
+#### Scenario: Source commits only after output success
+- **WHEN** the output confirms a write
+- **THEN** the WAL cursor advances past that message's sequence and only then is the source-side commit performed
+
+#### Scenario: Output failure withholds commit
+- **WHEN** the output fails to write a message
+- **THEN** the WAL cursor is not advanced past that sequence and the source is not committed, so the message is retried or replayed
+
+### Requirement: Crash recovery replays unacknowledged entries
+On startup, the Engine SHALL open each durability-enabled stream's WAL and replay every entry past the committed cursor into the stream before normal processing resumes.
+
+#### Scenario: Replay after crash
+- **WHEN** the engine starts with a WAL whose committed cursor is behind the maximum written sequence
+- **THEN** all entries past the committed cursor are replayed into the stream in sequence order before new input is read
+
+#### Scenario: Clean restart replays nothing
+- **WHEN** the engine starts with a WAL whose committed cursor equals the maximum written sequence
+- **THEN** no entries are replayed and the stream begins reading new input
+
+### Requirement: At-least-once delivery
+The system SHALL provide at-least-once delivery: after a crash and recovery, in-flight messages MAY be delivered more than once. Outputs MUST tolerate duplicates.
+
+#### Scenario: Duplicate delivery after recovery
+- **WHEN** a message was output successfully but the WAL cursor had not yet advanced before a crash
+- **THEN** on recovery the message is replayed and MAY be delivered to the output again
+
+### Requirement: Durability is orthogonal to windowing
+A stream MAY combine a durable ingest WAL with a windowing buffer. Enabling durability SHALL NOT disable or conflict with the configured `buffer`, and the buffer continues to operate on in-memory windowing semantics.
+
+#### Scenario: Durability and window buffer coexist
+- **WHEN** a stream is configured with both `durability.enabled: true` and a windowing `buffer`
+- **THEN** messages are persisted to the WAL on read AND pass through the windowing buffer as before
+
+### Requirement: Configurable and opt-in durability
+Durability SHALL be opt-in per stream via a `durability` configuration section. Streams without `durability` (or with `enabled: false`) SHALL retain today's in-memory, non-durable behavior. The sync policy (`per-entry` | `group-commit` | `periodic`) SHALL be configurable.
+
+#### Scenario: Opt-in default
+- **WHEN** a stream has no `durability` section
+- **THEN** the stream behaves as today (in-memory only, no WAL)
+
+#### Scenario: Explicit enable
+- **WHEN** a stream has `durability.enabled: true`
+- **THEN** a WAL is created at the configured path and durable ingestion is active

--- a/openspec/changes/archive/2026-07-26-add-input-durability/specs/message-acknowledgment/spec.md
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/specs/message-acknowledgment/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Acknowledgement is fallible
+The `Ack` trait SHALL return `Result<(), Error>` from `ack()`, so that failures during durable cursor advancement or source-side commit propagate to the stream instead of being swallowed.
+
+#### Scenario: Successful acknowledgement
+- **WHEN** a downstream output confirms a write and the WAL cursor advances successfully
+- **THEN** `ack()` returns `Ok(())` and the source-side commit (if any) is performed
+
+#### Scenario: Cursor advancement failure is surfaced
+- **WHEN** the durable cursor advancement fails (e.g. storage error, disk full)
+- **THEN** `ack()` returns `Err` and the stream is able to observe the failure to apply backpressure or stop, rather than silently continuing
+
+### Requirement: Composite acknowledgement propagates errors
+`VecAck` (and any composite ack aggregating multiple acknowledgements) SHALL return `Err` if any constituent acknowledgement fails, so that partial failure is not hidden.
+
+#### Scenario: One constituent fails
+- **WHEN** a composite acknowledgement acks multiple constituents and one returns `Err`
+- **THEN** the composite acknowledgement returns `Err`
+
+#### Scenario: No-op acknowledgement succeeds
+- **WHEN** a `NoopAck` is acked
+- **THEN** it returns `Ok(())` without side effect

--- a/openspec/changes/archive/2026-07-26-add-input-durability/tasks.md
+++ b/openspec/changes/archive/2026-07-26-add-input-durability/tasks.md
@@ -1,0 +1,48 @@
+## 1. Phase 0 — Source ack-gating audit (no breaking changes)
+
+- [x] 1.1 Audit Kafka input: confirm `enable.auto.commit=false` by default and that `store_offset` fires only inside `ack()`; document the requirement
+- [x] 1.2 Audit MQTT / NATS / Pulsar inputs: confirm manual ack on `ack()` only (no auto-ack before output); fix defaults if needed
+- [x] 1.3 Add integration test proving a replayable source → durable output survives a simulated mid-flight crash with auto-commit off
+- [x] 1.4 Document which inputs are replayable vs non-replayable (HTTP/File/Generate/Modbus/Redis/SQL/WebSocket = non-replayable)
+
+## 2. Fallible Ack trait (D2 — BREAKING)
+
+- [x] 2.1 Change `Ack::ack()` to `async fn ack(&self) -> Result<(), Error>` in `arkflow-core/src/input/mod.rs`
+- [x] 2.2 Update `NoopAck` → `Ok(())`; update `VecAck` to propagate the first `Err`
+- [x] 2.3 Update Kafka / MQTT / NATS / Pulsar `Ack` implementors to the new signature
+- [x] 2.4 Update all `ack.ack().await` call sites in `Stream` (`do_processor`, `output`, error paths) to handle `Result` (log + backpressure/stop on `Err`)
+- [x] 2.5 `cargo test --workspace` green after the signature change
+
+## 3. WAL storage layer (D4)
+
+- [x] 3.1 Add `redb` workspace dependency in root `Cargo.toml`
+- [x] 3.2 Implement a WAL module in `arkflow-core`: open at path, write `(seq → Arrow IPC bytes)`, advance committed cursor, read entries past cursor in order
+- [x] 3.3 Verify Arrow `RecordBatch` ↔ IPC bytes round-trip preserves schema and metadata columns (`__meta_*`)
+- [x] 3.4 Unit tests: write/read/advance-cursor, reopen after drop simulates recovery, corrupted-store open surfaces `Err`
+
+## 4. Stream-owned ingest stage + config (D3)
+
+- [x] 4.1 Add `DurabilityConfig` (`enabled`, `path`, `sync`, `flush_interval`) to `StreamConfig` and wire into `Stream::new`
+- [x] 4.2 Add the ingest stage to `Stream::run`: on `input.read()`, persist `(msg, seq)` + flush, then emit `(msg, WalAck{seq, inner_ack})`
+- [x] 4.3 Implement `WalAck`: on `ack()`, advance WAL cursor past `seq`, then call inner source ack; return `Err` if cursor advance fails
+- [x] 4.4 Ensure durability is orthogonal to the optional windowing `buffer` (both active when configured)
+- [x] 4.5 Default opt-in: stream without `durability` keeps today's in-memory behavior
+
+## 5. Sync policy (D5)
+
+- [x] 5.1 Implement `per-entry` / `group-commit` / `periodic` flush modes in the WAL
+- [x] 5.2 Default to `group-commit` with the configured `flush_interval`
+- [x] 5.3 Benchmark ingest throughput per mode; record before/after numbers
+
+## 6. Crash recovery (Engine startup)
+
+- [x] 6.1 Add a recovery phase to Engine startup: open each durability-enabled stream's WAL before `run()`
+- [x] 6.2 Replay entries past the committed cursor into the stream in sequence order before reading new input
+- [x] 6.3 Coordinate recovery ordering with `temporary` storage connect in `Stream::run` (resolve Open Question)
+- [x] 6.4 Integration test: inject crash after read, restart, assert replay delivers the message exactly (no loss) and tolerates duplicates (at-least-once)
+
+## 7. Documentation & contracts
+
+- [x] 7.1 Document the at-least-once contract and duplicate-tolerance requirement for outputs (especially HTTP/Kafka)
+- [x] 7.2 Add a `durability:` config example to `examples/`
+- [x] 7.3 Note the single-node boundary (process crash only, not node loss) in docs

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/input-durability/spec.md
+++ b/openspec/specs/input-durability/spec.md
@@ -1,0 +1,65 @@
+# Capability: Input Durability
+
+## Purpose
+
+Provide durable ingestion at the stream input boundary so that no data entering from any input is lost across crashes. Every message read by an input is persisted (body + sequence) and `fsync`'d to a Write-Ahead Log (WAL) before it enters the pipeline. The WAL cursor advances, and the source is committed, only after the downstream output confirms the write. On startup, the Engine replays any WAL entries past the committed cursor before streams resume, delivering at-least-once semantics.
+
+## Requirements
+
+### Requirement: Durable ingestion at the input boundary
+When durability is enabled for a stream, every message returned by `input.read()` SHALL be persisted (body + sequence) and durably flushed to the WAL before it enters the pipeline.
+
+#### Scenario: Message is durable before processing
+- **WHEN** an input reads a message on a durability-enabled stream
+- **THEN** the message body and an assigned sequence are written and flushed to the WAL before the message is handed to the buffer/processor
+
+#### Scenario: Crash after read does not lose data
+- **WHEN** the process crashes after `input.read()` returns but before the message is processed or output
+- **THEN** the message is present in the WAL on restart and is replayed
+
+### Requirement: Ack-gated cursor advancement and source commit
+The WAL cursor SHALL advance past a message's sequence, and the source-side acknowledgement SHALL be performed, only after the downstream output confirms the write. The source commit SHALL happen after the WAL cursor advances.
+
+#### Scenario: Source commits only after output success
+- **WHEN** the output confirms a write
+- **THEN** the WAL cursor advances past that message's sequence and only then is the source-side commit performed
+
+#### Scenario: Output failure withholds commit
+- **WHEN** the output fails to write a message
+- **THEN** the WAL cursor is not advanced past that sequence and the source is not committed, so the message is retried or replayed
+
+### Requirement: Crash recovery replays unacknowledged entries
+On startup, the Engine SHALL open each durability-enabled stream's WAL and replay every entry past the committed cursor into the stream before normal processing resumes.
+
+#### Scenario: Replay after crash
+- **WHEN** the engine starts with a WAL whose committed cursor is behind the maximum written sequence
+- **THEN** all entries past the committed cursor are replayed into the stream in sequence order before new input is read
+
+#### Scenario: Clean restart replays nothing
+- **WHEN** the engine starts with a WAL whose committed cursor equals the maximum written sequence
+- **THEN** no entries are replayed and the stream begins reading new input
+
+### Requirement: At-least-once delivery
+The system SHALL provide at-least-once delivery: after a crash and recovery, in-flight messages MAY be delivered more than once. Outputs MUST tolerate duplicates.
+
+#### Scenario: Duplicate delivery after recovery
+- **WHEN** a message was output successfully but the WAL cursor had not yet advanced before a crash
+- **THEN** on recovery the message is replayed and MAY be delivered to the output again
+
+### Requirement: Durability is orthogonal to windowing
+A stream MAY combine a durable ingest WAL with a windowing buffer. Enabling durability SHALL NOT disable or conflict with the configured `buffer`, and the buffer continues to operate on in-memory windowing semantics.
+
+#### Scenario: Durability and window buffer coexist
+- **WHEN** a stream is configured with both `durability.enabled: true` and a windowing `buffer`
+- **THEN** messages are persisted to the WAL on read AND pass through the windowing buffer as before
+
+### Requirement: Configurable and opt-in durability
+Durability SHALL be opt-in per stream via a `durability` configuration section. Streams without `durability` (or with `enabled: false`) SHALL retain today's in-memory, non-durable behavior. The sync policy (`per-entry` | `group-commit` | `periodic`) SHALL be configurable.
+
+#### Scenario: Opt-in default
+- **WHEN** a stream has no `durability` section
+- **THEN** the stream behaves as today (in-memory only, no WAL)
+
+#### Scenario: Explicit enable
+- **WHEN** a stream has `durability.enabled: true`
+- **THEN** a WAL is created at the configured path and durable ingestion is active

--- a/openspec/specs/message-acknowledgment/spec.md
+++ b/openspec/specs/message-acknowledgment/spec.md
@@ -1,0 +1,29 @@
+# Capability: Message Acknowledgment
+
+## Purpose
+
+Define the cross-cutting `Ack` contract used to confirm that a message has been durably processed. Acknowledgement is fallible so that failures during durable cursor advancement or source-side commit propagate to the stream instead of being silently swallowed, enabling the stream to apply backpressure or stop on persistent errors. Composite acknowledgements (e.g. `VecAck`) must surface partial failures rather than hide them.
+
+## Requirements
+
+### Requirement: Acknowledgement is fallible
+The `Ack` trait SHALL return `Result<(), Error>` from `ack()`, so that failures during durable cursor advancement or source-side commit propagate to the stream instead of being swallowed.
+
+#### Scenario: Successful acknowledgement
+- **WHEN** a downstream output confirms a write and the WAL cursor advances successfully
+- **THEN** `ack()` returns `Ok(())` and the source-side commit (if any) is performed
+
+#### Scenario: Cursor advancement failure is surfaced
+- **WHEN** the durable cursor advancement fails (e.g. storage error, disk full)
+- **THEN** `ack()` returns `Err` and the stream is able to observe the failure to apply backpressure or stop, rather than silently continuing
+
+### Requirement: Composite acknowledgement propagates errors
+`VecAck` (and any composite ack aggregating multiple acknowledgements) SHALL return `Err` if any constituent acknowledgement fails, so that partial failure is not hidden.
+
+#### Scenario: One constituent fails
+- **WHEN** a composite acknowledgement acks multiple constituents and one returns `Err`
+- **THEN** the composite acknowledgement returns `Err`
+
+#### Scenario: No-op acknowledgement succeeds
+- **WHEN** a `NoopAck` is acked
+- **THEN** it returns `Ok(())` without side effect


### PR DESCRIPTION
Closes the crash-loss window between `input.read()` and `ack.ack()` so that no data entering from any input is lost across a process crash.

## What's in this PR

- **Fallible `Ack` trait (BREAKING)**: `ack() -> Result<(), Error>`. All implementors updated (Kafka/MQTT/NATS/Pulsar/NoopAck/VecAck/ArrayAck). Stream call sites handle `Result` (log + backpressure on `Err`).
- **Kafka input crash-safety**: `enable.auto.offset.store = false` so offsets advance only on `ack()`, not on `recv()`. Verified by unit test. MQTT/NATS/Pulsar audited (manual ack only).
- **New WAL module** (`crates/arkflow-core/src/wal`, redb-backed): persists every message (Arrow IPC + input_name) + fsyncs before it enters the pipeline; cursor advances only after downstream output confirms. `WalAck` decorator wires the durable cursor to the existing ack-after-output plumbing. **Orthogonal** to the windowing buffer.
- **Stream-level crash recovery**: on startup, any WAL entries past the committed cursor are replayed into the pipeline before new input is read.
- **Three sync policies**: `per_entry` / `group_commit` (default) / `periodic`. Benchmark (5000 sequential appends, release): per_entry ~184/s, group_commit ~19,450/s, periodic(1ms) ~47,569/s — group-commit ~106× faster by amortizing fsync.
- **At-least-once semantics**: duplicates possible after recovery; outputs MUST tolerate.

## Documentation
- `docs/docs/components/0-inputs/delivery-semantics.md` (replayability classification + at-least-once contract + single-node boundary)
- `examples/durability_example.yaml`

## OpenSpec
Change `add-input-durability` (proposal/design/specs/tasks) archived under `openspec/changes/archive/2026-07-26-add-input-durability/`. Capabilities promoted to `openspec/specs/{message-acknowledgment,input-durability}`.

## Tests
`cargo test --workspace --lib`: **251 passed, 0 failed** (1 ignored = the release-mode benchmark; +1 ignored = the broker-gated Kafka redelivery test, gated on `ARKFLOW_KAFKA_BROKER`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-stream durability with write-ahead logging and configurable sync policies.
  * Added crash recovery that replays unacknowledged messages, providing at-least-once delivery.
  * Added a durability configuration example for local WAL storage.

* **Bug Fixes**
  * Acknowledgement failures are now surfaced and handled instead of being silently ignored.

* **Documentation**
  * Documented acknowledgement behavior, durability limits, recovery semantics, and duplicate-delivery expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->