### PR TITLE
fix(ci): bump pnpm to 10 in doc-deploy to match lockfile v9

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.10.5
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
The docs pnpm-lock.yaml uses lockfileVersion 9.0, which pnpm 8 cannot read. With pnpm 8.10.5 in this workflow, pnpm silently ignored the incompatible lockfile and re-resolved dependencies from scratch, pulling in webpack 5.109.0. That version tightened ProgressPlugin schema validation, which breaks webpackbar 6.0.1 used by Docusaurus 3.9.2 (it extends webpack.ProgressPlugin and passes legacy {name, color, reporters, reporter} options).

Bumping pnpm to 10 makes the install respect the lockfile, pinning webpack to the validated 5.104.1 and restoring green docs builds.

Aligns with test-doc-deploy.yml which already uses pnpm 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation deployment process to use pnpm version 10 for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->