### PR TITLE
feat: component metadata registry + JSON Schema for IDE auto-completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,29 @@ cargo test --package <name>    # Run tests for a specific package
 
 The binary supports configuration validation via the `--validate` flag.
 
+### Component Discovery & Configuration Schema
+
+The binary exposes commands for discovering registered components and their
+configuration schemas. These power IDE auto-completion and inline help.
+
+```bash
+# List every registered input / output / processor / buffer / codec
+./target/release/arkflow components list
+./target/release/arkflow components list --kind input
+
+# Print the full configuration schema for one component (text or JSON)
+./target/release/arkflow components show input kafka
+./target/release/arkflow components show processor sql --format json
+
+# Emit a complete JSON Schema describing the engine config. Point your
+# editor's YAML language server at this file to get field-level completion.
+./target/release/arkflow schema > arkflow.schema.json
+```
+
+Component variants are registered alongside their builders via
+`arkflow_core::component::register_*_metadata` and discovered through
+`arkflow_core::component::list_components`.
+
 ### CI Requirements
 The CI pipeline requires protobuf compiler:
 ```bash

--- a/crates/arkflow-core/src/cli/mod.rs
+++ b/crates/arkflow-core/src/cli/mod.rs
@@ -12,9 +12,10 @@
  *    limitations under the License.
  */
 
+use crate::component::{self, ComponentKind};
 use crate::config::{EngineConfig, LogFormat};
 use crate::engine::Engine;
-use clap::{Arg, Command};
+use clap::{Arg, ArgMatches, Command};
 use std::process;
 use tracing::{info, Level};
 use tracing_subscriber::fmt;
@@ -30,13 +31,56 @@ impl Cli {
             .version("0.4.0-rc1")
             .author("chenquan")
             .about("High-performance Rust stream processing engine, providing powerful data stream processing capabilities, supporting multiple input/output sources and processors.")
+            .subcommand(
+                Command::new("components")
+                    .about("Discover registered components and their configuration schemas.")
+                    .subcommand(
+                        Command::new("list")
+                            .about("List every registered component, grouped by kind.")
+                            .arg(
+                                Arg::new("kind")
+                                    .long("kind")
+                                    .short('k')
+                                    .value_name("KIND")
+                                    .help("Filter by component kind: input, output, processor, buffer, codec."),
+                            ),
+                    )
+                    .subcommand(
+                        Command::new("show")
+                            .about("Print the configuration schema for a specific component.")
+                            .arg(
+                                Arg::new("kind")
+                                    .value_name("KIND")
+                                    .required(true)
+                                    .help("Component kind: input, output, processor, buffer, codec."),
+                            )
+                            .arg(
+                                Arg::new("name")
+                                    .value_name("NAME")
+                                    .required(true)
+                                    .help("Registered component type name."),
+                            )
+                            .arg(
+                                Arg::new("format")
+                                    .long("format")
+                                    .short('f')
+                                    .value_name("FORMAT")
+                                    .default_value("text")
+                                    .help("Output format: text or json."),
+                            ),
+                    ),
+            )
+            .subcommand(
+                Command::new("schema")
+                    .about("Print the JSON Schema for the engine configuration (useful for IDE auto-completion)."),
+            )
             .arg(
                 Arg::new("config")
                     .short('c')
                     .long("config")
                     .value_name("FILE")
                     .help("Specify the profile path.")
-                    .required(true),
+                    .required(false),
             )
             .arg(
                 Arg::new("validate")
@@ -47,8 +91,26 @@ impl Cli {
             )
             .get_matches();
 
-        // Get the profile path
-        let config_path = matches.get_one::<String>("config").unwrap();
+        // Dispatch subcommands that don't require a config file.
+        match matches.subcommand() {
+            Some(("components", sub)) => {
+                handle_components_subcommand(sub)?;
+                process::exit(0);
+            }
+            Some(("schema", _)) => {
+                let schema = component::build_config_schema();
+                println!("{}", serde_json::to_string_pretty(&schema)?);
+                process::exit(0);
+            }
+            _ => {}
+        }
+
+        // Get the profile path; required when not running a subcommand.
+        let Some(config_path) = matches.get_one::<String>("config") else {
+            return Err(Box::new(Error::Config(
+                "missing --config <FILE> (or run a subcommand: components, schema)".to_string(),
+            )));
+        };
 
         // Get the profile path
         let config = match EngineConfig::from_file(config_path) {
@@ -68,14 +130,138 @@ impl Cli {
         Ok(())
     }
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        // `--validate` (and the subcommands handled inside `parse`) return
+        // without loading a config, so the engine should not be started.
+        let Some(config) = self.config.clone() else {
+            return Ok(());
+        };
         // Initialize the logging system
-        let config = self.config.clone().unwrap();
         init_logging(&config);
         let engine = Engine::new(config);
         engine.run().await?;
         Ok(())
     }
 }
+
+fn handle_components_subcommand(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+    match matches.subcommand() {
+        Some(("list", sub)) => {
+            let filter: Option<ComponentKind> = sub
+                .get_one::<String>("kind")
+                .map(|k| k.parse())
+                .transpose()?;
+            print_component_list(filter);
+            Ok(())
+        }
+        Some(("show", sub)) => {
+            let kind: ComponentKind = sub.get_one::<String>("kind").unwrap().parse()?;
+            let name = sub.get_one::<String>("name").unwrap();
+            let format = sub
+                .get_one::<String>("format")
+                .map(|s| s.as_str())
+                .unwrap_or("text");
+            print_component_details(kind, name, format)
+        }
+        _ => {
+            // `arkflow components` with no subcommand behaves like
+            // `arkflow components list` to keep the UX forgiving.
+            print_component_list(None);
+            Ok(())
+        }
+    }
+}
+
+fn print_component_list(filter: Option<ComponentKind>) {
+    let entries: Vec<(ComponentKind, _)> = match filter {
+        Some(kind) => component::list_components_by_kind(kind)
+            .into_iter()
+            .map(|m| (kind, m))
+            .collect(),
+        None => component::list_components(),
+    };
+
+    if entries.is_empty() {
+        println!("No components registered.");
+        return;
+    }
+
+    let mut current_kind: Option<ComponentKind> = None;
+    let name_width = entries
+        .iter()
+        .map(|(_, m)| m.name.len())
+        .max()
+        .unwrap_or(0)
+        .max(4);
+
+    for (kind, metadata) in &entries {
+        if current_kind != Some(*kind) {
+            if current_kind.is_some() {
+                println!();
+            }
+            println!("{}:", kind);
+            current_kind = Some(*kind);
+        }
+        println!(
+            "  {:<width$}  {}",
+            metadata.name,
+            metadata.description,
+            width = name_width
+        );
+    }
+}
+
+fn print_component_details(
+    kind: ComponentKind,
+    name: &str,
+    format: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let metadata = component::get_component_metadata(kind, name).ok_or_else(|| {
+        let known: Vec<String> = component::list_components_by_kind(kind)
+            .into_iter()
+            .map(|m| m.name.clone())
+            .collect();
+        let available = if known.is_empty() {
+            " (no components are registered for this kind)".to_string()
+        } else {
+            format!(". Available {} types: {}", kind, known.join(", "))
+        };
+        Error::Config(format!(
+            "Unknown {} type: {}{}",
+            kind, name, available
+        ))
+    })?;
+
+    match format {
+        "json" => {
+            let payload = serde_json::json!({
+                "kind": kind,
+                "name": metadata.name,
+                "description": metadata.description,
+                "config_optional": metadata.config_optional,
+                "config_schema": metadata.config_schema,
+                "config_example": metadata.config_example,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        }
+        _ => {
+            println!("{}: {}", metadata.name, metadata.description);
+            println!("kind: {}", kind);
+            println!(
+                "config_optional: {}",
+                if metadata.config_optional { "yes" } else { "no" }
+            );
+            if let Some(example) = &metadata.config_example {
+                println!("\nExample:");
+                println!("{}", serde_json::to_string_pretty(example)?);
+            }
+            println!("\nConfig schema:");
+            println!("{}", serde_json::to_string_pretty(&metadata.config_schema)?);
+        }
+    }
+    Ok(())
+}
+
+use crate::Error;
 fn init_logging(config: &EngineConfig) {
     let log_level = match config.logging.level.as_str() {
         "trace" => Level::TRACE,

--- a/crates/arkflow-core/src/component/mod.rs
+++ b/crates/arkflow-core/src/component/mod.rs
@@ -1,0 +1,619 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! Component metadata registry
+//!
+//! Each component (input / output / processor / buffer / codec) can be
+//! registered with a `ComponentMetadata` entry that describes it. The
+//! metadata powers three capabilities:
+//!
+//! 1. **Discovery** — `list_components()` lets callers enumerate every
+//!    registered component, so a CLI can render a catalogue, and tests can
+//!    assert a particular component is present.
+//! 2. **Detail completion** — `get_component_metadata()` returns a
+//!    JSON Schema for a component's configuration, so a CLI can render
+//!    help, and an IDE can drive auto-completion in YAML config files.
+//! 3. **Validation** — combining the schema with a config file lets the
+//!    engine validate user input without instantiating the component.
+
+use crate::Error;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+/// The kind of component being described.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ComponentKind {
+    Input,
+    Output,
+    Processor,
+    Buffer,
+    Codec,
+}
+
+impl ComponentKind {
+    /// Stable string representation used in CLI output and JSON Schema.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ComponentKind::Input => "input",
+            ComponentKind::Output => "output",
+            ComponentKind::Processor => "processor",
+            ComponentKind::Buffer => "buffer",
+            ComponentKind::Codec => "codec",
+        }
+    }
+
+    /// All kinds, in the canonical order used by listings and the schema.
+    pub const fn all() -> [ComponentKind; 5] {
+        [
+            ComponentKind::Input,
+            ComponentKind::Output,
+            ComponentKind::Processor,
+            ComponentKind::Buffer,
+            ComponentKind::Codec,
+        ]
+    }
+}
+
+impl std::fmt::Display for ComponentKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ComponentKind {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "input" => Ok(ComponentKind::Input),
+            "output" => Ok(ComponentKind::Output),
+            "processor" => Ok(ComponentKind::Processor),
+            "buffer" => Ok(ComponentKind::Buffer),
+            "codec" => Ok(ComponentKind::Codec),
+            other => Err(Error::Config(format!(
+                "Unknown component kind: {} (expected one of: input, output, processor, buffer, codec)",
+                other
+            ))),
+        }
+    }
+}
+
+/// Descriptor for a single component variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentMetadata {
+    /// Component type name (the value of `type:` in user config).
+    pub name: String,
+    /// Short, human-readable description of what the component does.
+    pub description: String,
+    /// When `true`, the configuration block is optional and the component
+    /// can be built with no `config` value present.
+    #[serde(default)]
+    pub config_optional: bool,
+    /// JSON Schema describing the component's configuration object.
+    /// When the component takes no configuration, this is an empty object
+    /// schema (`{"type": "object"}`).
+    pub config_schema: serde_json::Value,
+    /// Optional example configuration rendered in CLI help and IDE
+    /// hover / completion.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub config_example: Option<serde_json::Value>,
+}
+
+impl ComponentMetadata {
+    /// Build a metadata entry for a component that takes no configuration.
+    pub fn unit(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            config_optional: true,
+            config_schema: serde_json::json!({"type": "object"}),
+            config_example: None,
+        }
+    }
+
+    /// Build a metadata entry from a JSON Schema.
+    pub fn with_schema(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        schema: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            config_optional: false,
+            config_schema: schema,
+            config_example: None,
+        }
+    }
+
+    /// Mark the configuration as optional (e.g. when the component provides
+    /// sensible defaults).
+    pub fn with_optional(mut self) -> Self {
+        self.config_optional = true;
+        self
+    }
+
+    /// Attach an example configuration to the metadata.
+    pub fn with_example(mut self, example: serde_json::Value) -> Self {
+        self.config_example = Some(example);
+        self
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref INPUT_METADATA: RwLock<BTreeMap<String, Arc<ComponentMetadata>>> =
+        RwLock::new(BTreeMap::new());
+    static ref OUTPUT_METADATA: RwLock<BTreeMap<String, Arc<ComponentMetadata>>> =
+        RwLock::new(BTreeMap::new());
+    static ref PROCESSOR_METADATA: RwLock<BTreeMap<String, Arc<ComponentMetadata>>> =
+        RwLock::new(BTreeMap::new());
+    static ref BUFFER_METADATA: RwLock<BTreeMap<String, Arc<ComponentMetadata>>> =
+        RwLock::new(BTreeMap::new());
+    static ref CODEC_METADATA: RwLock<BTreeMap<String, Arc<ComponentMetadata>>> =
+        RwLock::new(BTreeMap::new());
+}
+
+macro_rules! register_metadata {
+    ($fn_name:ident, $registry:ident, $kind:expr) => {
+        /// Register metadata for a component variant. Must be called once
+        /// per `(kind, name)` pair, typically from the component's `init()`
+        /// function. Returns an error if the same name is registered twice.
+        pub fn $fn_name(metadata: ComponentMetadata) -> Result<(), Error> {
+            let mut registry = $registry.write().unwrap();
+            if registry.contains_key(&metadata.name) {
+                return Err(Error::Config(format!(
+                    "{} type already registered: {}",
+                    $kind, metadata.name
+                )));
+            }
+            registry.insert(metadata.name.clone(), Arc::new(metadata));
+            Ok(())
+        }
+    };
+}
+
+register_metadata!(register_input_metadata, INPUT_METADATA, ComponentKind::Input);
+register_metadata!(register_output_metadata, OUTPUT_METADATA, ComponentKind::Output);
+register_metadata!(register_processor_metadata, PROCESSOR_METADATA, ComponentKind::Processor);
+register_metadata!(register_buffer_metadata, BUFFER_METADATA, ComponentKind::Buffer);
+register_metadata!(register_codec_metadata, CODEC_METADATA, ComponentKind::Codec);
+
+macro_rules! list_metadata {
+    ($fn_name:ident, $registry:ident) => {
+        /// Return a snapshot of every component registered for this kind,
+        /// sorted by name.
+        pub fn $fn_name() -> Vec<Arc<ComponentMetadata>> {
+            $registry.read().unwrap().values().cloned().collect()
+        }
+    };
+}
+
+list_metadata!(list_input_components, INPUT_METADATA);
+list_metadata!(list_output_components, OUTPUT_METADATA);
+list_metadata!(list_processor_components, PROCESSOR_METADATA);
+list_metadata!(list_buffer_components, BUFFER_METADATA);
+list_metadata!(list_codec_components, CODEC_METADATA);
+
+/// Look up the metadata registry for a given kind.
+fn registry_for(kind: ComponentKind) -> &'static RwLock<BTreeMap<String, Arc<ComponentMetadata>>> {
+    match kind {
+        ComponentKind::Input => &INPUT_METADATA,
+        ComponentKind::Output => &OUTPUT_METADATA,
+        ComponentKind::Processor => &PROCESSOR_METADATA,
+        ComponentKind::Buffer => &BUFFER_METADATA,
+        ComponentKind::Codec => &CODEC_METADATA,
+    }
+}
+
+/// Register metadata for any component kind. Convenience wrapper that
+/// delegates to the kind-specific registration function.
+pub fn register_component_metadata(
+    kind: ComponentKind,
+    metadata: ComponentMetadata,
+) -> Result<(), Error> {
+    match kind {
+        ComponentKind::Input => register_input_metadata(metadata),
+        ComponentKind::Output => register_output_metadata(metadata),
+        ComponentKind::Processor => register_processor_metadata(metadata),
+        ComponentKind::Buffer => register_buffer_metadata(metadata),
+        ComponentKind::Codec => register_codec_metadata(metadata),
+    }
+}
+
+/// Look up metadata for a specific component. Returns `None` if no
+/// component with that name is registered for the given kind.
+pub fn get_component_metadata(
+    kind: ComponentKind,
+    name: &str,
+) -> Option<Arc<ComponentMetadata>> {
+    registry_for(kind).read().unwrap().get(name).cloned()
+}
+
+/// Return every component registered for the given kind, sorted by name.
+pub fn list_components_by_kind(kind: ComponentKind) -> Vec<Arc<ComponentMetadata>> {
+    registry_for(kind).read().unwrap().values().cloned().collect()
+}
+
+/// Return every registered component across all kinds, grouped by kind
+/// in the canonical order returned by [`ComponentKind::all`].
+pub fn list_components() -> Vec<(ComponentKind, Arc<ComponentMetadata>)> {
+    ComponentKind::all()
+        .into_iter()
+        .flat_map(|kind| {
+            list_components_by_kind(kind)
+                .into_iter()
+                .map(move |m| (kind, m))
+        })
+        .collect()
+}
+
+/// Build a JSON Schema describing the top-level engine configuration.
+///
+/// The returned schema is structured for IDE auto-completion:
+///
+/// * The root schema is an object with `logging`, `health_check`, and
+///   `streams` properties.
+/// * Each `streams[*]` entry allows the `input`, `output`, `error_output`,
+///   `buffer`, `pipeline.input`, `pipeline.output`, and
+///   `pipeline.processors` fields to be one of the registered component
+///   variants, using JSON Schema `oneOf` and `if/then/else` driven by
+///   the `type` discriminator.
+/// * The schema embeds each component's individual configuration schema
+///   under the matching variant, so editors can offer field-level
+///   completion once the user picks a `type`.
+pub fn build_config_schema() -> serde_json::Value {
+    let mut root = serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "ArkFlow engine configuration",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "logging": {
+                "type": "object",
+                "description": "Logging configuration.",
+                "additionalProperties": false,
+                "properties": {
+                    "level": {
+                        "type": "string",
+                        "enum": ["trace", "debug", "info", "warn", "error"],
+                        "default": "info",
+                        "description": "Log level."
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Optional path to a log file."
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["plain", "json"],
+                        "default": "plain",
+                        "description": "Log output format."
+                    }
+                }
+            },
+            "health_check": {
+                "type": "object",
+                "description": "Health check HTTP server configuration.",
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {"type": "boolean", "default": true},
+                    "address": {"type": "string", "default": "0.0.0.0:8080"},
+                    "health_path": {"type": "string", "default": "/health"},
+                    "readiness_path": {"type": "string", "default": "/readiness"},
+                    "liveness_path": {"type": "string", "default": "/liveness"}
+                }
+            },
+            "streams": {
+                "type": "array",
+                "description": "List of stream processing pipelines.",
+                "items": {"$ref": "#/$defs/stream"}
+            }
+        },
+        "required": ["streams"]
+    });
+
+    let defs = root.as_object_mut().unwrap();
+    defs.insert("$defs".to_string(), serde_json::json!({}));
+
+    // Build the per-component variant schemas once so we can reuse them.
+    let input_variants = variant_schemas(ComponentKind::Input);
+    let output_variants = variant_schemas(ComponentKind::Output);
+    let processor_variants = variant_schemas(ComponentKind::Processor);
+    let buffer_variants = variant_schemas(ComponentKind::Buffer);
+    let codec_variants = variant_schemas(ComponentKind::Codec);
+
+    let component_union = |variants: &serde_json::Value, kind: ComponentKind| -> serde_json::Value {
+        let variants = variants.as_array().cloned().unwrap_or_default();
+        if variants.is_empty() {
+            // No components registered for this kind — allow any object so
+            // existing configs still validate.
+            return serde_json::json!({
+                "type": "object",
+                "description": format!("No {} components are registered.", kind),
+            });
+        }
+        serde_json::json!({
+            "type": "object",
+            "description": format!("Select a registered {} component.", kind),
+            "required": ["type"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": variants.iter().map(|v| v["name"].clone()).collect::<Vec<_>>(),
+                    "description": format!("{} component type.", kind)
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional logical name for this component instance."
+                }
+            },
+            "oneOf": variants
+        })
+    };
+
+    let defs = defs.get_mut("$defs").unwrap().as_object_mut().unwrap();
+    defs.insert(
+        "input".to_string(),
+        component_union(&input_variants, ComponentKind::Input),
+    );
+    defs.insert(
+        "output".to_string(),
+        component_union(&output_variants, ComponentKind::Output),
+    );
+    defs.insert(
+        "processor".to_string(),
+        component_union(&processor_variants, ComponentKind::Processor),
+    );
+    defs.insert(
+        "buffer".to_string(),
+        component_union(&buffer_variants, ComponentKind::Buffer),
+    );
+    defs.insert(
+        "codec".to_string(),
+        component_union(&codec_variants, ComponentKind::Codec),
+    );
+    defs.insert(
+        "stream".to_string(),
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["input", "output", "pipeline"],
+            "properties": {
+                "input": {"$ref": "#/$defs/input"},
+                "output": {"$ref": "#/$defs/output"},
+                "error_output": {"$ref": "#/$defs/output"},
+                "pipeline": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["processors"],
+                    "properties": {
+                        "thread_num": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "description": "Number of processor worker threads."
+                        },
+                        "processors": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/processor"}
+                        },
+                        "input": {
+                            "type": "object",
+                            "description": "Stream-level input overrides (currently unused, reserved for future).",
+                            "additionalProperties": true
+                        },
+                        "output": {
+                            "type": "object",
+                            "description": "Stream-level output overrides (currently unused, reserved for future).",
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "buffer": {"$ref": "#/$defs/buffer"}
+            }
+        }),
+    );
+
+    root
+}
+
+/// Build the `oneOf` variant array for a given component kind. Each
+/// variant embeds the component's individual `config_schema` so that
+/// editors can offer field-level completion.
+fn variant_schemas(kind: ComponentKind) -> serde_json::Value {
+    let variants: Vec<serde_json::Value> = list_components_by_kind(kind)
+        .into_iter()
+        .map(|m| {
+            let mut props = serde_json::Map::new();
+            props.insert(
+                "type".to_string(),
+                serde_json::json!({
+                    "type": "string",
+                    "const": m.name,
+                    "description": m.description.clone()
+                }),
+            );
+            props.insert(
+                "name".to_string(),
+                serde_json::json!({
+                    "type": "string",
+                    "description": "Optional logical name for this instance."
+                }),
+            );
+
+            let mut config_subschema = m.config_schema.clone();
+            if let Some(obj) = config_subschema.as_object_mut() {
+                if !obj.contains_key("type") {
+                    obj.insert("type".to_string(), serde_json::json!("object"));
+                }
+            } else {
+                config_subschema = serde_json::json!({"type": "object"});
+            }
+
+            let mut properties = serde_json::Map::new();
+            properties.insert("type".to_string(), props["type"].clone());
+            properties.insert("name".to_string(), props["name"].clone());
+            properties.insert("codec".to_string(), codec_schema());
+            // The component-specific config keys are flattened into the
+            // top-level object, so we splice them in via a pattern of
+            // additionalProperties alongside an optional embedded schema.
+            if let Some(obj) = config_subschema.as_object() {
+                if let Some(inner_props) = obj.get("properties").and_then(|p| p.as_object()) {
+                    for (k, v) in inner_props {
+                        properties.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            let example = m.config_example.clone();
+            let mut variant = serde_json::json!({
+                "type": "object",
+                "title": m.name.clone(),
+                "description": m.description.clone(),
+                "properties": properties,
+                "required": ["type"]
+            });
+            if let Some(ex) = example {
+                variant.as_object_mut().unwrap().insert("examples".to_string(), serde_json::json!([ex]));
+            }
+            variant
+        })
+        .collect();
+    serde_json::Value::Array(variants)
+}
+
+fn codec_schema() -> serde_json::Value {
+    let variants: Vec<serde_json::Value> = list_components_by_kind(ComponentKind::Codec)
+        .into_iter()
+        .map(|m| {
+            serde_json::json!({
+                "type": "object",
+                "title": m.name,
+                "description": m.description,
+                "properties": {
+                    "type": {"type": "string", "const": m.name}
+                },
+                "required": ["type"]
+            })
+        })
+        .collect();
+    if variants.is_empty() {
+        return serde_json::json!({"type": "object"});
+    }
+    serde_json::json!({
+        "oneOf": variants
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Each test that registers metadata needs an isolated registry state;
+    // the simplest way is to use distinct component names per test.
+    static REGISTER_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn component_kind_as_str_and_from_str_round_trip() {
+        for kind in ComponentKind::all() {
+            let parsed: ComponentKind = kind.as_str().parse().unwrap();
+            assert_eq!(parsed, kind);
+        }
+    }
+
+    #[test]
+    fn component_kind_from_str_rejects_unknown() {
+        let err = "unknown".parse::<ComponentKind>().unwrap_err();
+        assert!(matches!(err, Error::Config(_)));
+    }
+
+    #[test]
+    fn unit_metadata_is_optional() {
+        let m = ComponentMetadata::unit("noop", "Does nothing.");
+        assert_eq!(m.name, "noop");
+        assert!(m.config_optional);
+        assert!(m.config_example.is_none());
+    }
+
+    #[test]
+    fn with_schema_metadata_chain() {
+        let m = ComponentMetadata::with_schema(
+            "demo",
+            "Demo component.",
+            serde_json::json!({"type": "object", "properties": {"x": {"type": "integer"}}}),
+        )
+        .with_optional()
+        .with_example(serde_json::json!({"x": 1}));
+        assert_eq!(m.name, "demo");
+        assert!(m.config_optional);
+        assert!(m.config_example.is_some());
+    }
+
+    #[test]
+    fn register_and_lookup_metadata() {
+        let _guard = REGISTER_LOCK.lock().unwrap();
+        let name = "test_lookup_component";
+        register_input_metadata(ComponentMetadata::unit(name, "Lookup test.")).unwrap();
+
+        let found = get_component_metadata(ComponentKind::Input, name).unwrap();
+        assert_eq!(found.name, name);
+        assert_eq!(found.description, "Lookup test.");
+        assert!(found.config_optional);
+
+        // Duplicate registration is rejected.
+        let dup = register_input_metadata(ComponentMetadata::unit(name, "again"));
+        assert!(matches!(dup, Err(Error::Config(_))));
+    }
+
+    #[test]
+    fn list_components_orders_by_kind() {
+        let _guard = REGISTER_LOCK.lock().unwrap();
+        let name = "test_listing_component";
+        register_buffer_metadata(ComponentMetadata::unit(name, "Listing test.")).unwrap();
+
+        let list = list_components();
+        let kinds: Vec<ComponentKind> = list.iter().map(|(k, _)| *k).collect();
+        let mut sorted = kinds.clone();
+        sorted.dedup();
+        assert_eq!(kinds, sorted, "kinds should appear in canonical order");
+
+        let found = list
+            .iter()
+            .find(|(_, m)| m.name == name)
+            .expect("registered component should appear in list");
+        assert_eq!(found.0, ComponentKind::Buffer);
+    }
+
+    #[test]
+    fn build_config_schema_contains_component_variants() {
+        let _guard = REGISTER_LOCK.lock().unwrap();
+        let name = "test_schema_component";
+        register_output_metadata(ComponentMetadata::unit(name, "Schema test.")).unwrap();
+
+        let schema = build_config_schema();
+        let variants = schema
+            .pointer("/$defs/output/oneOf")
+            .expect("output variants should be present");
+        let variants = variants.as_array().unwrap();
+        assert!(
+            variants.iter().any(|v| v
+                .pointer("/properties/type/const")
+                .and_then(|c| c.as_str())
+                == Some(name)),
+            "registered component should appear in output schema variants"
+        );
+    }
+}

--- a/crates/arkflow-core/src/lib.rs
+++ b/crates/arkflow-core/src/lib.rs
@@ -30,6 +30,7 @@ use thiserror::Error;
 pub mod buffer;
 pub mod cli;
 pub mod codec;
+pub mod component;
 pub mod config;
 pub mod engine;
 pub mod error_helpers;

--- a/crates/arkflow-plugin/src/buffer/memory.rs
+++ b/crates/arkflow-plugin/src/buffer/memory.rs
@@ -20,6 +20,7 @@
 
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
+use arkflow_core::component::{register_buffer_metadata, ComponentMetadata};
 use arkflow_core::input::Ack;
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -269,7 +270,20 @@ impl BufferBuilder for MemoryBufferBuilder {
 /// # Returns
 /// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
-    register_buffer_builder("memory", Arc::new(MemoryBufferBuilder))
+    register_buffer_builder("memory", Arc::new(MemoryBufferBuilder))?;
+    register_buffer_metadata(ComponentMetadata::with_schema(
+        "memory",
+        "In-memory buffer that releases a batch when it reaches capacity or after a timeout.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "capacity": {"type": "integer", "minimum": 1, "description": "Maximum number of messages to accumulate before releasing."},
+                "timeout": {"type": "string", "description": "Maximum time to wait before releasing a partial batch (humantime)."}
+            },
+            "required": ["capacity", "timeout"]
+        }),
+    ).with_example(serde_json::json!({"capacity": 1000, "timeout": "5s"})))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/buffer/session_window.rs
+++ b/crates/arkflow-plugin/src/buffer/session_window.rs
@@ -23,6 +23,7 @@ use crate::buffer::join::JoinConfig;
 use crate::buffer::window::BaseWindow;
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
+use arkflow_core::component::{register_buffer_metadata, ComponentMetadata};
 use arkflow_core::input::Ack;
 use arkflow_core::{Error, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -190,7 +191,29 @@ impl BufferBuilder for SessionWindowBuilder {
 /// # Returns
 /// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
-    register_buffer_builder("session_window", Arc::new(SessionWindowBuilder))
+    register_buffer_builder("session_window", Arc::new(SessionWindowBuilder))?;
+    register_buffer_metadata(ComponentMetadata::with_schema(
+        "session_window",
+        "Groups messages into sessions based on a maximum gap between messages. Supports SQL joins across sources.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "gap": {"type": "string", "description": "Maximum idle time before a session is closed (humantime)."},
+                "join": {
+                    "type": "object",
+                    "description": "Optional SQL join across input sources.",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "value_field": {"type": "string"},
+                        "codec": {"type": "object"},
+                        "thread_num": {"type": "integer", "minimum": 1}
+                    }
+                }
+            },
+            "required": ["gap"]
+        }),
+    ).with_example(serde_json::json!({"gap": "30s"})))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/buffer/sliding_window.rs
+++ b/crates/arkflow-plugin/src/buffer/sliding_window.rs
@@ -21,6 +21,7 @@
 
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
+use arkflow_core::component::{register_buffer_metadata, ComponentMetadata};
 use arkflow_core::input::{Ack, VecAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -278,7 +279,21 @@ impl BufferBuilder for SlidingWindowBuilder {
 /// # Returns
 /// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
-    register_buffer_builder("sliding_window", Arc::new(SlidingWindowBuilder))
+    register_buffer_builder("sliding_window", Arc::new(SlidingWindowBuilder))?;
+    register_buffer_metadata(ComponentMetadata::with_schema(
+        "sliding_window",
+        "Overlapping time windows that slide forward by a fixed interval.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "window_size": {"type": "integer", "minimum": 1, "description": "Number of messages included in each window."},
+                "interval": {"type": "string", "description": "Time interval between window emissions (humantime)."},
+                "slide_size": {"type": "integer", "minimum": 1, "description": "Number of messages to advance the window by on each emission."}
+            },
+            "required": ["window_size", "interval", "slide_size"]
+        }),
+    ).with_example(serde_json::json!({"window_size": 100, "interval": "5s", "slide_size": 20})))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/buffer/tumbling_window.rs
+++ b/crates/arkflow-plugin/src/buffer/tumbling_window.rs
@@ -23,6 +23,7 @@ use crate::buffer::join::JoinConfig;
 use crate::buffer::window::BaseWindow;
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
+use arkflow_core::component::{register_buffer_metadata, ComponentMetadata};
 use arkflow_core::input::Ack;
 use arkflow_core::{Error, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -176,7 +177,29 @@ impl BufferBuilder for TumblingWindowBuilder {
 /// # Returns
 /// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
-    register_buffer_builder("tumbling_window", Arc::new(TumblingWindowBuilder))
+    register_buffer_builder("tumbling_window", Arc::new(TumblingWindowBuilder))?;
+    register_buffer_metadata(ComponentMetadata::with_schema(
+        "tumbling_window",
+        "Fixed-size, non-overlapping time windows. Supports SQL joins across sources.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "interval": {"type": "string", "description": "Window duration (humantime)."},
+                "join": {
+                    "type": "object",
+                    "description": "Optional SQL join across input sources.",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "value_field": {"type": "string"},
+                        "codec": {"type": "object"},
+                        "thread_num": {"type": "integer", "minimum": 1}
+                    }
+                }
+            },
+            "required": ["interval"]
+        }),
+    ).with_example(serde_json::json!({"interval": "1m"})))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/codec/json.rs
+++ b/crates/arkflow-plugin/src/codec/json.rs
@@ -13,6 +13,7 @@
  */
 use crate::component;
 use arkflow_core::codec::{Codec, CodecBuilder, Decoder, Encoder};
+use arkflow_core::component::{register_codec_metadata, ComponentMetadata};
 use arkflow_core::{codec, Bytes, Error, MessageBatch, Resource};
 use datafusion::arrow;
 use serde_json::Value;
@@ -60,6 +61,17 @@ impl CodecBuilder for JsonCodecBuilder {
 
 pub(crate) fn init() -> Result<(), Error> {
     codec::register_codec_builder("json", Arc::new(JsonCodecBuilder))?;
+    register_codec_metadata(ComponentMetadata::with_schema(
+        "json",
+        "Encodes/decodes Arrow RecordBatches as JSON byte payloads.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pretty": {"type": "boolean", "default": false, "description": "Pretty-print JSON output."}
+            }
+        }),
+    ).with_optional())?;
     Ok(())
 }
 

--- a/crates/arkflow-plugin/src/codec/protobuf.rs
+++ b/crates/arkflow-plugin/src/codec/protobuf.rs
@@ -20,6 +20,7 @@ use crate::component::protobuf::{
     arrow_to_protobuf, parse_proto_file, protobuf_to_arrow, ProtobufConfig,
 };
 use arkflow_core::codec::{Codec, CodecBuilder, Decoder, Encoder};
+use arkflow_core::component::{register_codec_metadata, ComponentMetadata};
 use arkflow_core::{codec, Bytes, Error, MessageBatch, Resource};
 use datafusion::arrow;
 use datafusion::arrow::datatypes::Schema;
@@ -131,6 +132,20 @@ impl CodecBuilder for ProtobufCodecBuilder {
 
 pub(crate) fn init() -> Result<(), Error> {
     codec::register_codec_builder("protobuf", Arc::new(ProtobufCodecBuilder))?;
+    register_codec_metadata(ComponentMetadata::with_schema(
+        "protobuf",
+        "Encodes/decodes Arrow RecordBatches using a Protobuf descriptor.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type name."},
+                "proto_inputs": {"type": "array", "items": {"type": "string"}, "description": "Paths to .proto files."},
+                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."}
+            },
+            "required": ["message_type", "proto_inputs"]
+        }),
+    ))?;
     Ok(())
 }
 

--- a/crates/arkflow-plugin/src/input/file.rs
+++ b/crates/arkflow-plugin/src/input/file.rs
@@ -14,6 +14,7 @@
 
 use crate::udf;
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     input::{Ack, Input, InputBuilder, NoopAck},
@@ -479,7 +480,22 @@ impl InputBuilder for FileBuilder {
 
 pub fn init() -> Result<(), Error> {
     arkflow_core::input::register_input_builder("file", Arc::new(FileBuilder))?;
-    Ok(())
+    register_input_metadata(ComponentMetadata::with_schema(
+        "file",
+        "Reads records from local or remote object storage (S3, GCS, Azure, HDFS) in CSV/JSON/Parquet/Avro/Arrow formats.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "input_type": {"type": "object", "description": "Format-specific input settings (type: csv/json/parquet/avro/arrow)."},
+                "ballista": {"type": "object", "description": "Optional Ballista distributed compute configuration."},
+                "query": {"type": "object", "description": "Optional SQL query and table name to filter the read."}
+            },
+            "required": ["input_type"]
+        }),
+    ).with_example(serde_json::json!({
+        "input_type": {"type": "parquet", "path": "s3://bucket/data.parquet"}
+    })))
 }
 
 fn default_disallow_http() -> bool {

--- a/crates/arkflow-plugin/src/input/generate.rs
+++ b/crates/arkflow-plugin/src/input/generate.rs
@@ -14,6 +14,7 @@
 
 use crate::time::deserialize_duration;
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -119,7 +120,42 @@ impl InputBuilder for GenerateInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("generate", Arc::new(GenerateInputBuilder))
+    register_input_builder("generate", Arc::new(GenerateInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "generate",
+        "Generates synthetic text messages on a fixed interval (useful for testing and load simulation).",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "context": {
+                    "type": "string",
+                    "description": "Payload string emitted on every read."
+                },
+                "interval": {
+                    "type": "string",
+                    "description": "Delay between batches (e.g. '100ms', '1s'). Accepts any humantime duration."
+                },
+                "count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional total number of messages to emit before signalling EOF."
+                },
+                "batch_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Number of messages returned per read call."
+                }
+            },
+            "required": ["context", "interval"]
+        }),
+    ).with_example(serde_json::json!({
+        "context": "hello",
+        "interval": "1s",
+        "count": 100,
+        "batch_size": 10
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/input/http.rs
+++ b/crates/arkflow-plugin/src/input/http.rs
@@ -17,6 +17,7 @@
 //! Receive data from HTTP endpoints
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -215,7 +216,28 @@ impl InputBuilder for HttpInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("http", Arc::new(HttpInputBuilder))
+    register_input_builder("http", Arc::new(HttpInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "http",
+        "Receives data via HTTP. Can run as a server (POST/PUT on `path`) or poll a remote endpoint.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "address": {"type": "string", "description": "Bind address (server mode) or base URL (client mode)."},
+                "path": {"type": "string", "description": "Path to accept messages on (server mode) or full request path (client mode)."},
+                "method": {"type": "string", "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"], "description": "HTTP method (client mode)."},
+                "interval": {"type": "string", "description": "Polling interval in humantime format (client mode, e.g. '5s')."},
+                "cors_enabled": {"type": "boolean", "default": false, "description": "Enable CORS for the server."},
+                "auth": {"type": "object", "description": "Authentication configuration."}
+            },
+            "required": ["address", "path"]
+        }),
+    ).with_example(serde_json::json!({
+        "address": "0.0.0.0:8080",
+        "path": "/ingest",
+        "cors_enabled": true
+    })))
 }
 
 async fn validate_auth(headers: &HeaderMap, auth_config: &AuthType) -> bool {

--- a/crates/arkflow-plugin/src/input/kafka.rs
+++ b/crates/arkflow-plugin/src/input/kafka.rs
@@ -17,6 +17,7 @@
 //! Receive data from a Kafka topic
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder};
 use arkflow_core::{metadata, Error, MessageBatch, MessageBatchRef, Resource};
@@ -309,7 +310,31 @@ impl InputBuilder for KafkaInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("kafka", Arc::new(KafkaInputBuilder))
+    register_input_builder("kafka", Arc::new(KafkaInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "kafka",
+        "Consumes messages from Apache Kafka topics with a consumer group.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "brokers": {"type": "array", "items": {"type": "string"}, "description": "List of Kafka broker addresses."},
+                "topics": {"type": "array", "items": {"type": "string"}, "description": "Topics to subscribe to."},
+                "consumer_group": {"type": "string", "description": "Consumer group ID for offset coordination."},
+                "client_id": {"type": "string", "description": "Optional client identifier."},
+                "start_from_latest": {"type": "boolean", "default": false, "description": "When true, ignore committed offsets and start from the latest message."},
+                "fetch_min_bytes": {"type": "integer", "minimum": 0, "description": "Minimum bytes before the broker responds to a fetch request."},
+                "fetch_max_bytes": {"type": "integer", "minimum": 0, "description": "Maximum bytes for a fetch request."},
+                "fetch_max_partition_bytes": {"type": "integer", "minimum": 0, "description": "Maximum bytes per partition in a fetch request."},
+                "fetch_wait_max_ms": {"type": "integer", "minimum": 0, "description": "Maximum time to wait for fetch data in milliseconds."}
+            },
+            "required": ["brokers", "topics", "consumer_group"]
+        }),
+    ).with_example(serde_json::json!({
+        "brokers": ["localhost:9092"],
+        "topics": ["events"],
+        "consumer_group": "arkflow"
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/input/memory.rs
+++ b/crates/arkflow-plugin/src/input/memory.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -141,7 +142,20 @@ impl InputBuilder for MemoryInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("memory", Arc::new(MemoryInputBuilder))
+    register_input_builder("memory", Arc::new(MemoryInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "memory",
+        "In-memory input queue seeded with an initial list of messages. Primarily for tests and demos.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "messages": {"type": "array", "items": {"type": "string"}, "description": "Initial messages to enqueue."}
+            }
+        }),
+    ).with_optional().with_example(serde_json::json!({
+        "messages": ["hello", "world"]
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/input/modbus.rs
+++ b/crates/arkflow-plugin/src/input/modbus.rs
@@ -13,6 +13,7 @@
  */
 use crate::time::deserialize_duration;
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::{
     input::{Ack, Input, InputBuilder, NoopAck},
     Error, MessageBatch, MessageBatchRef, Resource,
@@ -235,5 +236,37 @@ impl InputBuilder for ModbusInputBuilder {
 
 pub fn init() -> Result<(), Error> {
     arkflow_core::input::register_input_builder("modbus", Arc::new(ModbusInputBuilder))?;
-    Ok(())
+    register_input_metadata(ComponentMetadata::with_schema(
+        "modbus",
+        "Polls Modbus TCP devices on a fixed interval, reading coils, discrete inputs, or registers.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "addr": {"type": "string", "description": "Modbus server address (host:port)."},
+                "slave_id": {"type": "integer", "description": "Modbus unit / slave ID."},
+                "points": {
+                    "type": "array",
+                    "description": "Points to read on every poll.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {"type": "string", "enum": ["coils", "discrete_inputs", "holding_registers", "input_registers"]},
+                            "name": {"type": "string"},
+                            "address": {"type": "integer"},
+                            "quantity": {"type": "integer", "minimum": 1}
+                        },
+                        "required": ["type", "name", "address", "quantity"]
+                    }
+                },
+                "interval": {"type": "string", "description": "Poll interval (humantime)."}
+            },
+            "required": ["addr", "slave_id", "points", "interval"]
+        }),
+    ).with_example(serde_json::json!({
+        "addr": "127.0.0.1:502",
+        "slave_id": 1,
+        "interval": "1s",
+        "points": [{"type": "holding_registers", "name": "voltage", "address": 0, "quantity": 1}]
+    })))
 }

--- a/crates/arkflow-plugin/src/input/mqtt.rs
+++ b/crates/arkflow-plugin/src/input/mqtt.rs
@@ -17,6 +17,7 @@
 //! Receive data from the MQTT broker
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -272,5 +273,30 @@ impl InputBuilder for MqttInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("mqtt", Arc::new(MqttInputBuilder))
+    register_input_builder("mqtt", Arc::new(MqttInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "mqtt",
+        "Subscribes to an MQTT broker and forwards messages from the configured topics.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "host": {"type": "string", "description": "MQTT broker hostname."},
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535, "description": "MQTT broker port."},
+                "client_id": {"type": "string", "description": "Unique client identifier."},
+                "username": {"type": "string", "description": "Optional username."},
+                "password": {"type": "string", "description": "Optional password."},
+                "topics": {"type": "array", "items": {"type": "string"}, "description": "Topics to subscribe to (MQTT wildcards supported)."},
+                "qos": {"type": "integer", "enum": [0, 1, 2], "default": 0, "description": "Quality of Service level."},
+                "clean_session": {"type": "boolean", "default": true, "description": "Whether to use a clean session."},
+                "keep_alive": {"type": "integer", "minimum": 1, "description": "Keep-alive interval in seconds."}
+            },
+            "required": ["host", "port", "client_id", "topics"]
+        }),
+    ).with_example(serde_json::json!({
+        "host": "localhost",
+        "port": 1883,
+        "client_id": "arkflow",
+        "topics": ["sensors/#"]
+    })))
 }

--- a/crates/arkflow-plugin/src/input/multiple_inputs.rs
+++ b/crates/arkflow-plugin/src/input/multiple_inputs.rs
@@ -12,6 +12,7 @@
  *    limitations under the License.
  */
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     input::{Ack, Input, InputBuilder, InputConfig},
@@ -181,5 +182,32 @@ pub(crate) fn init() -> Result<(), Error> {
         "multiple_inputs",
         Arc::new(MultipleInputsBuilder),
     )?;
-    Ok(())
+    register_input_metadata(ComponentMetadata::with_schema(
+        "multiple_inputs",
+        "Combines multiple input sources into a single stream. Each source is tagged with __meta_source.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inputs": {
+                    "type": "array",
+                    "description": "List of input components to combine.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {"type": "string", "description": "Input type (e.g. 'kafka', 'http')."},
+                            "name": {"type": "string", "description": "Optional logical name for this source."}
+                        },
+                        "required": ["type"]
+                    }
+                }
+            },
+            "required": ["inputs"]
+        }),
+    ).with_example(serde_json::json!({
+        "inputs": [
+            {"type": "kafka", "name": "events", "topics": ["events"]},
+            {"type": "kafka", "name": "logs", "topics": ["logs"]}
+        ]
+    })))
 }

--- a/crates/arkflow-plugin/src/input/nats.rs
+++ b/crates/arkflow-plugin/src/input/nats.rs
@@ -17,6 +17,7 @@
 //! Receive data from a NATS subject
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -468,7 +469,31 @@ impl Ack for NatsAck {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("nats", Arc::new(NatsInputBuilder))
+    register_input_builder("nats", Arc::new(NatsInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "nats",
+        "Consumes messages from NATS, supporting both regular subjects and JetStream consumers.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {"type": "string", "description": "NATS server URL (e.g. nats://localhost:4222)."},
+                "mode": {
+                    "type": "object",
+                    "description": "Select between plain NATS and JetStream subscriptions.",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "regular"}, "subject": {"type": "string"}, "queue_group": {"type": "string"}}, "required": ["type", "subject"]},
+                        {"properties": {"type": {"const": "jet_stream"}, "stream": {"type": "string"}, "consumer_name": {"type": "string"}, "durable_name": {"type": "string"}}, "required": ["type", "stream", "consumer_name"]}
+                    ]
+                },
+                "auth": {"type": "object", "description": "NATS authentication configuration."}
+            },
+            "required": ["url", "mode"]
+        }),
+    ).with_example(serde_json::json!({
+        "url": "nats://localhost:4222",
+        "mode": {"type": "regular", "subject": "events"}
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/input/pulsar.rs
+++ b/crates/arkflow-plugin/src/input/pulsar.rs
@@ -20,6 +20,7 @@ use crate::pulsar::{
     PulsarAuth, PulsarClientUtils, PulsarConfigValidator, RetryConfig, SubscriptionType,
 };
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -335,5 +336,26 @@ impl Ack for PulsarAck {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("pulsar", Arc::new(PulsarInputBuilder))
+    register_input_builder("pulsar", Arc::new(PulsarInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "pulsar",
+        "Subscribes to an Apache Pulsar topic with configurable subscription type and authentication.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "service_url": {"type": "string", "description": "Pulsar service URL (e.g. pulsar://localhost:6650)."},
+                "topic": {"type": "string", "description": "Topic to subscribe to."},
+                "subscription_name": {"type": "string", "description": "Subscription name."},
+                "subscription_type": {"type": "string", "enum": ["Exclusive", "Shared", "Failover", "KeyShared"], "description": "Subscription type."},
+                "auth": {"type": "object", "description": "Pulsar authentication configuration."},
+                "retry_config": {"type": "object", "description": "Retry behaviour for failed messages."}
+            },
+            "required": ["service_url", "topic", "subscription_name"]
+        }),
+    ).with_example(serde_json::json!({
+        "service_url": "pulsar://localhost:6650",
+        "topic": "persistent://public/default/events",
+        "subscription_name": "arkflow"
+    })))
 }

--- a/crates/arkflow-plugin/src/input/redis.rs
+++ b/crates/arkflow-plugin/src/input/redis.rs
@@ -17,6 +17,7 @@
 //! Receive data from Redis pub/sub channels
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
 
@@ -493,5 +494,38 @@ impl InputBuilder for RedisInputBuilder {
 
 /// Initialize Redis input component
 pub fn init() -> Result<(), Error> {
-    register_input_builder("redis", Arc::new(RedisInputBuilder))
+    register_input_builder("redis", Arc::new(RedisInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "redis",
+        "Reads from Redis: list blocking pops, pub/sub subscriptions, or stream consumer groups.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mode": {
+                    "type": "object",
+                    "description": "Connection mode.",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "cluster"}, "urls": {"type": "array", "items": {"type": "string"}}}, "required": ["type", "urls"]},
+                        {"properties": {"type": {"const": "single"}, "url": {"type": "string"}}, "required": ["type", "url"]}
+                    ]
+                },
+                "redis_type": {
+                    "type": "object",
+                    "description": "Data structure to consume from.",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "subscribe"}, "subscribe": {"type": "object", "oneOf": [
+                            {"properties": {"type": {"const": "channels"}, "channels": {"type": "array", "items": {"type": "string"}}}, "required": ["type", "channels"]},
+                            {"properties": {"type": {"const": "patterns"}, "patterns": {"type": "array", "items": {"type": "string"}}}, "required": ["type", "patterns"]}
+                        ]}}, "required": ["type", "subscribe"]},
+                        {"properties": {"type": {"const": "list"}, "list": {"type": "array", "items": {"type": "string"}}}, "required": ["type", "list"]}
+                    ]
+                }
+            },
+            "required": ["mode", "redis_type"]
+        }),
+    ).with_example(serde_json::json!({
+        "mode": {"type": "single", "url": "redis://localhost:6379"},
+        "redis_type": {"type": "list", "list": ["events"]}
+    })))
 }

--- a/crates/arkflow-plugin/src/input/sql.rs
+++ b/crates/arkflow-plugin/src/input/sql.rs
@@ -13,6 +13,7 @@
  */
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -340,5 +341,24 @@ impl InputBuilder for SqlInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("sql", Arc::new(SqlInputBuilder))
+    register_input_builder("sql", Arc::new(SqlInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "sql",
+        "Polls a SQL database (MySQL / PostgreSQL / SQLite / DuckDB) with a SELECT statement and emits rows as batches.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "select_sql": {"type": "string", "description": "SELECT statement to execute on every poll."},
+                "poll_interval": {"type": "string", "description": "Optional poll interval (humantime)."},
+                "ballista": {"type": "object", "description": "Optional Ballista distributed compute configuration."},
+                "input_type": {"type": "object", "description": "Database connection settings."}
+            },
+            "required": ["select_sql", "input_type"]
+        }),
+    ).with_example(serde_json::json!({
+        "select_sql": "SELECT id, name FROM users",
+        "poll_interval": "10s",
+        "input_type": {"type": "sqlite", "uri": "file:./data.db"}
+    })))
 }

--- a/crates/arkflow-plugin/src/input/websocket.rs
+++ b/crates/arkflow-plugin/src/input/websocket.rs
@@ -17,6 +17,7 @@
 //! Receive data from a WebSocket server
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_input_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::input::{register_input_builder, Ack, Input, InputBuilder, NoopAck};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -262,5 +263,21 @@ impl InputBuilder for WebSocketInputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_input_builder("websocket", Arc::new(WebSocketInputBuilder))
+    register_input_builder("websocket", Arc::new(WebSocketInputBuilder))?;
+    register_input_metadata(ComponentMetadata::with_schema(
+        "websocket",
+        "Connects to a WebSocket server and forwards each incoming message as a batch.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {"type": "string", "description": "WebSocket server URL (ws:// or wss://)."},
+                "headers": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Headers included in the WebSocket handshake."},
+                "timeout": {"type": "integer", "minimum": 1, "description": "Connection timeout in seconds."}
+            },
+            "required": ["url"]
+        }),
+    ).with_example(serde_json::json!({
+        "url": "ws://localhost:8080/stream"
+    })))
 }

--- a/crates/arkflow-plugin/src/output/drop.rs
+++ b/crates/arkflow-plugin/src/output/drop.rs
@@ -18,6 +18,7 @@
 //! It's useful for testing or when you want to intentionally discard data.
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatchRef, Resource};
 use async_trait::async_trait;
@@ -60,7 +61,11 @@ impl OutputBuilder for DropOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("drop", Arc::new(DropOutputBuilder))
+    register_output_builder("drop", Arc::new(DropOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::unit(
+        "drop",
+        "Discards all messages. Useful for performance benchmarks and dead-end pipelines.",
+    ))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/output/http.rs
+++ b/crates/arkflow-plugin/src/output/http.rs
@@ -16,6 +16,7 @@
 //!
 //! Send the processed data to the HTTP endpoint
 
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     codec::Codec,
@@ -231,5 +232,28 @@ impl OutputBuilder for HttpOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("http", Arc::new(HttpOutputBuilder))
+    register_output_builder("http", Arc::new(HttpOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "http",
+        "Posts each batch to an HTTP endpoint. Supports custom headers, retry, and auth.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {"type": "string", "description": "Destination URL."},
+                "method": {"type": "string", "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"], "default": "POST", "description": "HTTP method."},
+                "timeout_ms": {"type": "integer", "minimum": 1, "description": "Request timeout in milliseconds."},
+                "retry_count": {"type": "integer", "minimum": 0, "description": "Number of retry attempts on failure."},
+                "headers": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Custom HTTP headers."},
+                "body_field": {"type": "string", "description": "Record field that holds the request body."},
+                "auth": {"type": "object", "description": "Authentication configuration."}
+            },
+            "required": ["url"]
+        }),
+    ).with_example(serde_json::json!({
+        "url": "https://example.com/ingest",
+        "method": "POST",
+        "timeout_ms": 5000,
+        "retry_count": 3
+    })))
 }

--- a/crates/arkflow-plugin/src/output/influxdb.rs
+++ b/crates/arkflow-plugin/src/output/influxdb.rs
@@ -17,6 +17,7 @@
 //! Write the processed data to InfluxDB 2.x
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -519,7 +520,35 @@ impl OutputBuilder for InfluxDBOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("influxdb", Arc::new(InfluxDBOutputBuilder))
+    register_output_builder("influxdb", Arc::new(InfluxDBOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "influxdb",
+        "Writes time-series data to InfluxDB v2.x using the Line Protocol.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {"type": "string", "description": "InfluxDB server URL (e.g. http://localhost:8086)."},
+                "org": {"type": "string", "description": "Organization name."},
+                "bucket": {"type": "string", "description": "Destination bucket."},
+                "token": {"type": "string", "description": "Authentication token."},
+                "measurement": {"type": "string", "description": "Measurement name."},
+                "tags": {"type": "array", "description": "Tag mappings (label fields)."},
+                "fields": {"type": "array", "description": "Field mappings (value fields)."},
+                "timestamp_field": {"type": "string", "description": "Source field for the point timestamp."},
+                "batch_size": {"type": "integer", "minimum": 1, "description": "Batch size for write requests."},
+                "flush_interval": {"type": "string", "description": "Maximum time to wait before flushing a partial batch."}
+            },
+            "required": ["url", "org", "bucket", "token", "measurement", "fields"]
+        }),
+    ).with_example(serde_json::json!({
+        "url": "http://localhost:8086",
+        "org": "arkflow",
+        "bucket": "metrics",
+        "token": "${INFLUX_TOKEN}",
+        "measurement": "sensor",
+        "fields": [{"name": "value", "value_type": "float"}]
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/output/kafka.rs
+++ b/crates/arkflow-plugin/src/output/kafka.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use arkflow_core::{
     codec::Codec,
+    component::{register_output_metadata, ComponentMetadata},
     output::{register_output_builder, Output, OutputBuilder},
     Error, MessageBatch, MessageBatchRef, Resource, DEFAULT_BINARY_VALUE_FIELD,
 };
@@ -308,5 +309,26 @@ impl OutputBuilder for KafkaOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("kafka", Arc::new(KafkaOutputBuilder))
+    register_output_builder("kafka", Arc::new(KafkaOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "kafka",
+        "Produces messages to Apache Kafka. Supports key-based partitioning and compression.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "brokers": {"type": "array", "items": {"type": "string"}, "description": "List of Kafka broker addresses."},
+                "topic": {"type": "string", "description": "Destination topic (supports {field} placeholders)."},
+                "key": {"type": "string", "description": "Field used as the message key for partitioning."},
+                "client_id": {"type": "string", "description": "Optional client identifier."},
+                "compression": {"type": "string", "enum": ["none", "gzip", "snappy", "lz4", "zstd"], "description": "Compression algorithm."},
+                "acks": {"type": "string", "enum": ["0", "1", "all"], "description": "Acknowledgment level."},
+                "value_field": {"type": "string", "description": "Record field used as the message payload."}
+            },
+            "required": ["brokers", "topic"]
+        }),
+    ).with_example(serde_json::json!({
+        "brokers": ["localhost:9092"],
+        "topic": "events"
+    })))
 }

--- a/crates/arkflow-plugin/src/output/mqtt.rs
+++ b/crates/arkflow-plugin/src/output/mqtt.rs
@@ -17,6 +17,7 @@
 //! Send the processed data to the MQTT broker
 
 use crate::expr::Expr;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     codec::Codec,
@@ -218,7 +219,30 @@ impl OutputBuilder for MqttOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("mqtt", Arc::new(MqttOutputBuilder))
+    register_output_builder("mqtt", Arc::new(MqttOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "mqtt",
+        "Publishes messages to an MQTT broker topic.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "host": {"type": "string", "description": "MQTT broker hostname."},
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535, "description": "MQTT broker port."},
+                "client_id": {"type": "string", "description": "Client identifier."},
+                "username": {"type": "string", "description": "Optional username."},
+                "password": {"type": "string", "description": "Optional password."},
+                "topic": {"type": "string", "description": "Destination topic (supports {field} placeholders)."},
+                "qos": {"type": "integer", "enum": [0, 1, 2], "default": 0, "description": "Quality of Service."},
+                "clean_session": {"type": "boolean", "default": true},
+                "keep_alive": {"type": "integer", "minimum": 1, "description": "Keep-alive interval in seconds."},
+                "retain": {"type": "boolean", "default": false, "description": "Whether to retain the message on the broker."}
+            },
+            "required": ["host", "port", "client_id", "topic"]
+        }),
+    ).with_example(serde_json::json!({
+        "host": "localhost", "port": 1883, "client_id": "arkflow", "topic": "sensors/data"
+    })))
 }
 
 #[async_trait]

--- a/crates/arkflow-plugin/src/output/nats.rs
+++ b/crates/arkflow-plugin/src/output/nats.rs
@@ -17,6 +17,7 @@
 //! Send data to a NATS subject
 
 use crate::expr::Expr;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     codec::Codec,
@@ -229,7 +230,32 @@ impl OutputBuilder for NatsOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("nats", Arc::new(NatsOutputBuilder))
+    register_output_builder("nats", Arc::new(NatsOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "nats",
+        "Publishes to NATS, either to a regular subject or a JetStream stream.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {"type": "string", "description": "NATS server URL."},
+                "mode": {
+                    "type": "object",
+                    "description": "Select regular or JetStream publishing.",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "regular"}, "subject": {"type": "string"}}, "required": ["type", "subject"]},
+                        {"properties": {"type": {"const": "jet_stream"}, "stream": {"type": "string"}, "subject": {"type": "string"}}, "required": ["type", "stream", "subject"]}
+                    ]
+                },
+                "auth": {"type": "object", "description": "NATS authentication configuration."},
+                "value_field": {"type": "string", "description": "Record field used as the payload."}
+            },
+            "required": ["url", "mode"]
+        }),
+    ).with_example(serde_json::json!({
+        "url": "nats://localhost:4222",
+        "mode": {"type": "regular", "subject": "events"}
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/output/pulsar.rs
+++ b/crates/arkflow-plugin/src/output/pulsar.rs
@@ -20,6 +20,7 @@ use crate::expr::Expr;
 use crate::pulsar::{
     PulsarAuth, PulsarClient, PulsarClientUtils, PulsarConfigValidator, PulsarProducer,
 };
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     codec::Codec,
@@ -204,5 +205,23 @@ impl OutputBuilder for PulsarOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("pulsar", Arc::new(PulsarOutputBuilder))
+    register_output_builder("pulsar", Arc::new(PulsarOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "pulsar",
+        "Produces messages to an Apache Pulsar topic.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "service_url": {"type": "string", "description": "Pulsar service URL."},
+                "topic": {"type": "string", "description": "Destination topic (supports {field} placeholders)."},
+                "auth": {"type": "object", "description": "Pulsar authentication configuration."},
+                "value_field": {"type": "string", "description": "Record field used as the payload."}
+            },
+            "required": ["service_url", "topic"]
+        }),
+    ).with_example(serde_json::json!({
+        "service_url": "pulsar://localhost:6650",
+        "topic": "persistent://public/default/events"
+    })))
 }

--- a/crates/arkflow-plugin/src/output/redis.rs
+++ b/crates/arkflow-plugin/src/output/redis.rs
@@ -13,6 +13,7 @@
  */
 use crate::component::redis::{Connection, Mode};
 use crate::expr::Expr;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::{
     codec::Codec,
@@ -188,5 +189,37 @@ impl OutputBuilder for RedisOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    arkflow_core::output::register_output_builder("redis", Arc::new(RedisOutputBuilder))
+    arkflow_core::output::register_output_builder("redis", Arc::new(RedisOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "redis",
+        "Writes messages to Redis: streams, lists, or pub/sub channels.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mode": {
+                    "type": "object",
+                    "description": "Connection mode (single or cluster).",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "cluster"}, "urls": {"type": "array", "items": {"type": "string"}}}, "required": ["type", "urls"]},
+                        {"properties": {"type": {"const": "single"}, "url": {"type": "string"}}, "required": ["type", "url"]}
+                    ]
+                },
+                "redis_type": {
+                    "type": "object",
+                    "description": "Destination data structure.",
+                    "oneOf": [
+                        {"properties": {"type": {"const": "stream"}, "stream": {"type": "string"}}, "required": ["type", "stream"]},
+                        {"properties": {"type": {"const": "list"}, "list": {"type": "string"}}, "required": ["type", "list"]},
+                        {"properties": {"type": {"const": "channel"}, "channel": {"type": "string"}}, "required": ["type", "channel"]}
+                    ]
+                },
+                "value_field": {"type": "string", "description": "Record field used as the payload."}
+            },
+            "required": ["mode", "redis_type"]
+        }),
+    ).with_example(serde_json::json!({
+        "mode": {"type": "single", "url": "redis://localhost:6379"},
+        "redis_type": {"type": "stream", "stream": "events"}
+    })))
 }

--- a/crates/arkflow-plugin/src/output/sql.rs
+++ b/crates/arkflow-plugin/src/output/sql.rs
@@ -11,6 +11,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{codec::Codec, Error, MessageBatch, MessageBatchRef, Resource};
@@ -434,5 +435,25 @@ impl OutputBuilder for SqlOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("sql", Arc::new(SqlOutputBuilder))
+    register_output_builder("sql", Arc::new(SqlOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "sql",
+        "Batch-inserts records into a SQL database. Supports upsert and transaction management.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "connection": {"type": "object", "description": "Database connection settings (type, uri, etc.)."},
+                "table": {"type": "string", "description": "Destination table."},
+                "batch_size": {"type": "integer", "minimum": 1, "description": "Number of rows per insert batch."},
+                "upsert": {"type": "boolean", "default": false, "description": "Use upsert (ON CONFLICT) instead of plain insert."},
+                "upsert_keys": {"type": "array", "items": {"type": "string"}, "description": "Columns used to detect conflicts for upsert."}
+            },
+            "required": ["connection", "table"]
+        }),
+    ).with_example(serde_json::json!({
+        "connection": {"type": "postgres", "uri": "postgres://user:pass@localhost/db"},
+        "table": "events",
+        "batch_size": 500
+    })))
 }

--- a/crates/arkflow-plugin/src/output/stdout.rs
+++ b/crates/arkflow-plugin/src/output/stdout.rs
@@ -17,6 +17,7 @@
 //! Outputs the processed data to standard output
 
 use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
 use arkflow_core::error_helpers::parse_config;
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
@@ -106,7 +107,18 @@ impl OutputBuilder for StdoutOutputBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_output_builder("stdout", Arc::new(StdoutOutputBuilder))
+    register_output_builder("stdout", Arc::new(StdoutOutputBuilder))?;
+    register_output_metadata(ComponentMetadata::with_schema(
+        "stdout",
+        "Writes each message to the console. Useful for debugging and demos.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pretty": {"type": "boolean", "default": false, "description": "Pretty-print JSON output."}
+            }
+        }),
+    ).with_optional().with_example(serde_json::json!({"pretty": true})))
 }
 
 trait StdWriter: Write + Send + Sync {}

--- a/crates/arkflow-plugin/src/processor/batch.rs
+++ b/crates/arkflow-plugin/src/processor/batch.rs
@@ -16,6 +16,7 @@
 //!
 //! Batch multiple messages into one or more messages
 
+use arkflow_core::component::{register_processor_metadata, ComponentMetadata};
 use arkflow_core::processor::{register_processor_builder, Processor, ProcessorBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, ProcessResult, Resource};
 use async_trait::async_trait;
@@ -143,7 +144,20 @@ impl ProcessorBuilder for BatchProcessorBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_processor_builder("batch", Arc::new(BatchProcessorBuilder))
+    register_processor_builder("batch", Arc::new(BatchProcessorBuilder))?;
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "batch",
+        "Batches messages by count, size, or time interval before forwarding.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "count": {"type": "integer", "minimum": 1, "description": "Maximum number of messages per batch."},
+                "size": {"type": "integer", "minimum": 1, "description": "Approximate maximum byte size per batch."},
+                "interval": {"type": "string", "description": "Maximum time to wait before flushing a partial batch (humantime)."}
+            }
+        }),
+    ).with_optional().with_example(serde_json::json!({"count": 100, "interval": "5s"})))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -17,6 +17,7 @@
 //! A processor for converting between binary data and the Arrow format
 
 use crate::component;
+use arkflow_core::component::{register_processor_metadata, ComponentMetadata as CoreComponentMetadata};
 use arkflow_core::processor::{register_processor_builder, Processor, ProcessorBuilder};
 use arkflow_core::{
     Bytes, Error, MessageBatch, MessageBatchRef, ProcessResult, Resource,
@@ -154,6 +155,28 @@ impl ProcessorBuilder for ArrowToJsonProcessorBuilder {
 pub fn init() -> Result<(), Error> {
     register_processor_builder("arrow_to_json", Arc::new(ArrowToJsonProcessorBuilder))?;
     register_processor_builder("json_to_arrow", Arc::new(JsonToArrowProcessorBuilder))?;
+    register_processor_metadata(CoreComponentMetadata::with_schema(
+        "arrow_to_json",
+        "Converts an Arrow RecordBatch into JSON byte payloads (one per row).",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pretty": {"type": "boolean", "default": false, "description": "Pretty-print JSON output."}
+            }
+        }),
+    ).with_optional())?;
+    register_processor_metadata(CoreComponentMetadata::with_schema(
+        "json_to_arrow",
+        "Parses JSON byte payloads into an Arrow RecordBatch with inferred schema.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "batch_size": {"type": "integer", "minimum": 1, "description": "Rows per output batch."}
+            }
+        }),
+    ).with_optional())?;
     Ok(())
 }
 

--- a/crates/arkflow-plugin/src/processor/protobuf.rs
+++ b/crates/arkflow-plugin/src/processor/protobuf.rs
@@ -19,6 +19,7 @@
 use crate::component::protobuf::{
     arrow_to_protobuf, parse_proto_file, protobuf_to_arrow, ProtobufConfig,
 };
+use arkflow_core::component::{register_processor_metadata, ComponentMetadata};
 use arkflow_core::processor::{register_processor_builder, Processor, ProcessorBuilder};
 use arkflow_core::{
     Error, MessageBatch, MessageBatchRef, ProcessResult, Resource, DEFAULT_BINARY_VALUE_FIELD,
@@ -240,6 +241,34 @@ pub fn init() -> Result<(), Error> {
         "protobuf_to_arrow",
         Arc::new(ProtobufToArrowProcessorBuilder),
     )?;
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "arrow_to_protobuf",
+        "Serializes Arrow RecordBatches into Protobuf wire-format bytes.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type name."},
+                "proto_inputs": {"type": "array", "items": {"type": "string"}, "description": "Paths to .proto files."},
+                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."}
+            },
+            "required": ["message_type", "proto_inputs"]
+        }),
+    ))?;
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "protobuf_to_arrow",
+        "Decodes Protobuf wire-format bytes into Arrow RecordBatches.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type name."},
+                "proto_inputs": {"type": "array", "items": {"type": "string"}, "description": "Paths to .proto files."},
+                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."}
+            },
+            "required": ["message_type", "proto_inputs"]
+        }),
+    ))?;
     Ok(())
 }
 

--- a/crates/arkflow-plugin/src/processor/python.rs
+++ b/crates/arkflow-plugin/src/processor/python.rs
@@ -11,6 +11,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+use arkflow_core::component::{register_processor_metadata, ComponentMetadata};
 use arkflow_core::processor::{Processor, ProcessorBuilder};
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, ProcessResult, Resource};
 use async_trait::async_trait;
@@ -175,5 +176,22 @@ fn default_module() -> String {
 }
 
 pub fn init() -> Result<(), Error> {
-    arkflow_core::processor::register_processor_builder("python", Arc::new(PythonProcessorBuilder))
+    arkflow_core::processor::register_processor_builder("python", Arc::new(PythonProcessorBuilder))?;
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "python",
+        "Runs a user-defined Python function (with PyArrow) against each batch.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "script": {"type": "string", "description": "Python source defining the transform function."},
+                "function": {"type": "string", "description": "Name of the function to invoke for each batch."},
+                "extra_packages": {"type": "array", "items": {"type": "string"}, "description": "Optional list of pip packages to install before running."}
+            },
+            "required": ["script", "function"]
+        }),
+    ).with_example(serde_json::json!({
+        "script": "def transform(batch):\n    return batch",
+        "function": "transform"
+    })))
 }

--- a/crates/arkflow-plugin/src/processor/sql.rs
+++ b/crates/arkflow-plugin/src/processor/sql.rs
@@ -17,6 +17,7 @@
 //! DataFusion is used to process data with SQL queries.
 
 use crate::{context_pool::SessionContextPool, expr};
+use arkflow_core::component::{register_processor_metadata, ComponentMetadata};
 use arkflow_core::processor::{register_processor_builder, Processor, ProcessorBuilder};
 use arkflow_core::temporary::Temporary;
 use arkflow_core::{Error, MessageBatch, MessageBatchRef, ProcessResult, Resource};
@@ -244,7 +245,35 @@ impl ProcessorBuilder for SqlProcessorBuilder {
 }
 
 pub fn init() -> Result<(), Error> {
-    register_processor_builder("sql", Arc::new(SqlProcessorBuilder))
+    register_processor_builder("sql", Arc::new(SqlProcessorBuilder))?;
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "sql",
+        "Runs a DataFusion SQL query against each batch. Supports window functions and joins against temporary tables.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "query": {"type": "string", "description": "SQL query to run on every batch."},
+                "table_name": {"type": "string", "description": "Name used for the batch table in the query (default 'flow')."},
+                "temporary_list": {
+                    "type": "array",
+                    "description": "Temporary tables to register before running the query.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "table_name": {"type": "string"},
+                            "key": {"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]}
+                        },
+                        "required": ["name", "table_name", "key"]
+                    }
+                }
+            },
+            "required": ["query"]
+        }),
+    ).with_example(serde_json::json!({
+        "query": "SELECT *, __meta_source AS source FROM flow"
+    })))
 }
 
 #[cfg(test)]

--- a/crates/arkflow-plugin/src/processor/vrl.rs
+++ b/crates/arkflow-plugin/src/processor/vrl.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use arkflow_core::{
+    component::{register_processor_metadata, ComponentMetadata},
     processor::{register_processor_builder, Processor, ProcessorBuilder},
     Error, MessageBatch, MessageBatchRef, ProcessResult, Resource,
 };
@@ -23,7 +24,20 @@ use vrl::{
 
 pub fn init() -> Result<(), Error> {
     register_processor_builder("vrl", Arc::new(VrlProcessorBuilder))?;
-    Ok(())
+    register_processor_metadata(ComponentMetadata::with_schema(
+        "vrl",
+        "Runs a Vector Remap Language (VRL) program against each batch for safe transformation and enrichment.",
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "statement": {"type": "string", "description": "VRL program source."}
+            },
+            "required": ["statement"]
+        }),
+    ).with_example(serde_json::json!({
+        "statement": ".message = parse_json!(.message)\n.timestamp = now()"
+    })))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Introduce a `component` module in `arkflow-core` that lets every registered input, output, processor, buffer, and codec publish a `ComponentMetadata` entry alongside its builder. The metadata carries a human-readable description, a JSON Schema for the component's configuration, and an optional example.

The new metadata powers three new CLI subcommands:

* `arkflow components list [--kind <kind>]` — enumerate every registered component grouped by kind.
* `arkflow components show <kind> <name> [--format text|json]` — print a single component's description and configuration schema.
* `arkflow schema` — emit a complete JSON Schema describing the engine configuration. Point an IDE's YAML language server at this file to get field-level auto-completion in `config.yaml`.

All 39 input, output, processor, buffer, and codec components now register their schema on `init()`, including a concise description, required/optional fields, defaults, and a working example.

## Why

Users currently have to read source code or external documentation to know what configuration options a component supports, what fields are required, and what the correct type/spelling is. This change:

* Makes every supported component discoverable from the CLI itself.
* Gives IDEs the structure they need to auto-complete and validate `config.yaml`.
* Provides a single source of truth for component metadata that is also exercised by unit tests.

## Test plan

* `cargo test --workspace` — 304 tests pass, including 7 new tests in the `component` module.
* `./target/debug/arkflow components list` — prints every registered component grouped by kind with a description.
* `./target/debug/arkflow components show input kafka` — prints the full kafka config schema and example.
* `./target/debug/arkflow components show input nonexistent` — returns a helpful error listing the available input types.
* `./target/debug/arkflow schema > arkflow.schema.json` — produces valid JSON (~3.4k lines) covering all components.

## Bug fix

`--validate` used to panic on `cli.run()` because the config was never loaded. The CLI now no-ops `run()` when the config is missing, matching the existing `--validate` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list components and display their configuration schemas in text or JSON.
  * Added complete engine configuration schema generation for editor and YAML language-server completion.
  * Added descriptive schemas and examples for built-in inputs, outputs, processors, buffers, and codecs.
* **Documentation**
  * Documented component discovery, configuration schema commands, and metadata registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->