### PR TITLE
fix(plugin): harden VRL and protobuf against silent data loss

### DIFF
--- a/crates/arkflow-plugin/src/codec/protobuf.rs
+++ b/crates/arkflow-plugin/src/codec/protobuf.rs
@@ -14,7 +14,15 @@
 
 //! Protobuf Codec Components
 //!
-//! The codec used to convert between Protobuf data and the Arrow format
+//! The codec used to convert between Protobuf data and the Arrow format.
+//!
+//! # Supported field types
+//!
+//! Scalar proto3 fields are supported: `bool`, `int32`/`sint32`/`sfixed32`,
+//! `int64`/`sint64`/`sfixed64`, `uint32`/`fixed32`, `uint64`/`fixed64`,
+//! `float`, `double`, `string`, `bytes`, and `enum` (mapped to Arrow `Int32`).
+//! Nested message / repeated / map / oneof / proto3 optional fields are NOT
+//! supported and produce an error.
 
 use crate::component::protobuf::{
     arrow_to_protobuf, parse_proto_file, protobuf_to_arrow, ProtobufConfig,
@@ -27,7 +35,6 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use prost_reflect::MessageDescriptor;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::sync::Arc;
 
 /// Protobuf codec configuration
@@ -152,7 +159,10 @@ pub(crate) fn init() -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field};
     use std::cell::RefCell;
+    use tempfile::TempDir;
 
     fn create_test_resource() -> Resource {
         Resource {
@@ -242,5 +252,63 @@ mod tests {
 
         // Should fail due to invalid JSON structure
         assert!(result.is_err());
+    }
+
+    fn create_test_proto_file() -> Result<(TempDir, std::path::PathBuf), Error> {
+        let dir = tempfile::tempdir()
+            .map_err(|e| Error::Process(format!("Failed to create temp dir: {}", e)))?;
+        let proto_dir = dir.path().join("proto");
+        std::fs::create_dir_all(&proto_dir)
+            .map_err(|e| Error::Process(format!("Failed to create proto dir: {}", e)))?;
+        let proto_file_path = proto_dir.join("test_message.proto");
+        std::fs::write(
+            &proto_file_path,
+            r#"syntax = "proto3";
+
+package test;
+
+message TestMessage {
+  int64 timestamp = 1;
+  double value = 2;
+  string sensor = 3;
+}
+"#,
+        )
+        .map_err(|e| Error::Process(format!("Failed to write proto file: {}", e)))?;
+        Ok((dir, proto_dir))
+    }
+
+    #[test]
+    fn test_codec_round_trip() -> Result<(), Error> {
+        let (_x, proto_dir) = create_test_proto_file()?;
+        let config = serde_json::json!({
+            "proto_inputs": [proto_dir.to_string_lossy()],
+            "message_type": "test.TestMessage",
+        });
+        let codec = ProtobufCodecBuilder.build(None, &Some(config), &create_test_resource())?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("sensor", DataType::Utf8, false),
+        ]));
+        let rb = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1634567890])),
+                Arc::new(Float64Array::from(vec![42.5])),
+                Arc::new(StringArray::from(vec!["temperature"])),
+            ],
+        )
+        .map_err(|e| Error::Process(format!("Failed to create record batch: {}", e)))?;
+        let original = MessageBatch::new_arrow(rb);
+
+        let encoded = codec.encode(original)?;
+        assert_eq!(encoded.len(), 1, "one row → one encoded message");
+        let decoded = codec.decode(encoded)?;
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded.column(0).data_type(), &DataType::Int64);
+
+        Ok(())
     }
 }

--- a/crates/arkflow-plugin/src/component/protobuf.rs
+++ b/crates/arkflow-plugin/src/component/protobuf.rs
@@ -16,6 +16,17 @@
 //!
 //! This module contains shared functionality for Protobuf processing
 //! used by both codec and processor components.
+//!
+//! # Supported field types
+//!
+//! Scalar proto3 fields are supported in both directions (Arrow ↔ Protobuf):
+//! `bool`, `int32`/`sint32`/`sfixed32`, `int64`/`sint64`/`sfixed64`,
+//! `uint32`/`fixed32`, `uint64`/`fixed64`, `float`, `double`, `string`,
+//! `bytes`, and `enum` (mapped to Arrow `Int32`).
+//!
+//! **Not supported**: nested message fields, `repeated` fields, `map` fields,
+//! `oneof` fields, and proto3 `optional` fields. Encountering any of these
+//! returns an error naming the field and its kind.
 
 use arkflow_core::{Bytes, Error, MessageBatch};
 use datafusion::arrow::array::{
@@ -62,7 +73,7 @@ pub fn parse_proto_file<T: ProtobufConfig>(config: &T) -> Result<FileDescriptorS
         proto_inputs.extend(
             files_in_dir_result
                 .iter()
-                .filter(|path| path.extension().map_or(false, |ext| ext == "proto"))
+                .filter(|path| path.extension().is_some_and(|ext| ext == "proto"))
                 .filter_map(|path| path.to_str().map(|s| s.to_string()))
                 .collect::<Vec<_>>(),
         )
@@ -113,6 +124,10 @@ pub fn parse_proto_file<T: ProtobufConfig>(config: &T) -> Result<FileDescriptorS
 }
 
 /// Convert Protobuf data to Arrow format
+///
+/// The schema is driven by the message descriptor's full field set (every field
+/// nullable), so every decoded message yields the same schema regardless of
+/// which fields are present — making the per-message batches safe to concatenate.
 pub fn protobuf_to_arrow(
     descriptor: &MessageDescriptor,
     data: &[u8],
@@ -121,64 +136,104 @@ pub fn protobuf_to_arrow(
         .map_err(|e| Error::Process(format!("Protobuf message parsing failed: {}", e)))?;
 
     let descriptor_fields = descriptor.fields();
-    // Building an Arrow Schema
     let mut fields = Vec::with_capacity(descriptor_fields.len());
     let mut columns: Vec<ArrayRef> = Vec::with_capacity(descriptor_fields.len());
 
-    // Iterate over all fields of a Protobuf message
     for field in descriptor_fields {
         let field_name = field.name();
-
+        // Look up the value; an absent field becomes a null column (descriptor-driven schema).
         let field_value_opt = proto_msg.get_field_by_name(field_name);
-        if field_value_opt.is_none() {
-            continue;
-        }
-        let field_value = field_value_opt.unwrap();
-        match field_value.as_ref() {
-            Value::Bool(value) => {
-                fields.push(Field::new(field_name, DataType::Boolean, false));
-                columns.push(Arc::new(BooleanArray::from(vec![value.clone()])));
+
+        match field.kind() {
+            prost_reflect::Kind::Bool => {
+                fields.push(Field::new(field_name, DataType::Boolean, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::Bool(b)) => Some(*b),
+                    _ => None,
+                };
+                columns.push(Arc::new(BooleanArray::from(vec![v])));
             }
-            Value::I32(value) => {
-                fields.push(Field::new(field_name, DataType::Int32, false));
-                columns.push(Arc::new(Int32Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Int32
+            | prost_reflect::Kind::Sint32
+            | prost_reflect::Kind::Sfixed32 => {
+                fields.push(Field::new(field_name, DataType::Int32, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::I32(i)) => Some(*i),
+                    _ => None,
+                };
+                columns.push(Arc::new(Int32Array::from(vec![v])));
             }
-            Value::I64(value) => {
-                fields.push(Field::new(field_name, DataType::Int64, false));
-                columns.push(Arc::new(Int64Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Int64
+            | prost_reflect::Kind::Sint64
+            | prost_reflect::Kind::Sfixed64 => {
+                fields.push(Field::new(field_name, DataType::Int64, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::I64(i)) => Some(*i),
+                    _ => None,
+                };
+                columns.push(Arc::new(Int64Array::from(vec![v])));
             }
-            Value::U32(value) => {
-                fields.push(Field::new(field_name, DataType::UInt32, false));
-                columns.push(Arc::new(UInt32Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Uint32 | prost_reflect::Kind::Fixed32 => {
+                fields.push(Field::new(field_name, DataType::UInt32, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::U32(i)) => Some(*i),
+                    _ => None,
+                };
+                columns.push(Arc::new(UInt32Array::from(vec![v])));
             }
-            Value::U64(value) => {
-                fields.push(Field::new(field_name, DataType::UInt64, false));
-                columns.push(Arc::new(UInt64Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Uint64 | prost_reflect::Kind::Fixed64 => {
+                fields.push(Field::new(field_name, DataType::UInt64, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::U64(i)) => Some(*i),
+                    _ => None,
+                };
+                columns.push(Arc::new(UInt64Array::from(vec![v])));
             }
-            Value::F32(value) => {
-                fields.push(Field::new(field_name, DataType::Float32, false));
-                columns.push(Arc::new(Float32Array::from(vec![value.clone()])))
+            prost_reflect::Kind::Float => {
+                fields.push(Field::new(field_name, DataType::Float32, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::F32(f)) => Some(*f),
+                    _ => None,
+                };
+                columns.push(Arc::new(Float32Array::from(vec![v])));
             }
-            Value::F64(value) => {
-                fields.push(Field::new(field_name, DataType::Float64, false));
-                columns.push(Arc::new(Float64Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Double => {
+                fields.push(Field::new(field_name, DataType::Float64, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::F64(f)) => Some(*f),
+                    _ => None,
+                };
+                columns.push(Arc::new(Float64Array::from(vec![v])));
             }
-            Value::String(value) => {
-                fields.push(Field::new(field_name, DataType::Utf8, false));
-                columns.push(Arc::new(StringArray::from(vec![value.clone()])));
+            prost_reflect::Kind::String => {
+                fields.push(Field::new(field_name, DataType::Utf8, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::String(s)) => Some(s.clone()),
+                    _ => None,
+                };
+                columns.push(Arc::new(StringArray::from(vec![v])));
             }
-            Value::Bytes(value) => {
-                fields.push(Field::new(field_name, DataType::Binary, false));
-                columns.push(Arc::new(BinaryArray::from(vec![value.as_ref()])));
+            prost_reflect::Kind::Bytes => {
+                fields.push(Field::new(field_name, DataType::Binary, true));
+                let v: Option<&[u8]> = match field_value_opt.as_deref() {
+                    Some(Value::Bytes(b)) => Some(b.as_ref()),
+                    _ => None,
+                };
+                columns.push(Arc::new(BinaryArray::from(vec![v])));
             }
-            Value::EnumNumber(value) => {
-                fields.push(Field::new(field_name, DataType::Int32, false));
-                columns.push(Arc::new(Int32Array::from(vec![value.clone()])));
+            prost_reflect::Kind::Enum(_) => {
+                fields.push(Field::new(field_name, DataType::Int32, true));
+                let v = match field_value_opt.as_deref() {
+                    Some(Value::EnumNumber(n)) => Some(*n),
+                    _ => None,
+                };
+                columns.push(Arc::new(Int32Array::from(vec![v])));
             }
             _ => {
                 return Err(Error::Process(format!(
-                    "Unsupported field type: {}",
-                    field_name
+                    "Unsupported field type for field '{}': kind {:?}",
+                    field_name,
+                    field.kind()
                 )));
             }
         }
@@ -191,16 +246,19 @@ pub fn protobuf_to_arrow(
 }
 
 /// Convert Arrow format to Protobuf
+///
+/// A type mismatch between an Arrow column and its proto field returns an error
+/// (rather than silently dropping the field), and null Arrow values are left
+/// unset in the encoded proto message.
 pub fn arrow_to_protobuf(
     descriptor: &MessageDescriptor,
     batch: &MessageBatch,
 ) -> Result<Vec<Bytes>, Error> {
-    // Create a new dynamic message
+    // Create a new dynamic message per row
     let mut vec = Vec::with_capacity(batch.len());
     let len = batch.len();
     for _ in 0..len {
-        let proto_msg = DynamicMessage::new(descriptor.clone());
-        vec.push(proto_msg);
+        vec.push(DynamicMessage::new(descriptor.clone()));
     }
 
     // Get the Arrow schema.
@@ -214,120 +272,137 @@ pub fn arrow_to_protobuf(
 
             match proto_field.kind() {
                 prost_reflect::Kind::Bool => {
-                    if let Some(value) = column.as_any().downcast_ref::<BooleanArray>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::Bool(value.value(j)));
+                    let value = typed_column::<BooleanArray>(column, field_name, "Bool")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::Bool(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Int32
                 | prost_reflect::Kind::Sint32
                 | prost_reflect::Kind::Sfixed32 => {
-                    if let Some(value) = column.as_any().downcast_ref::<Int32Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::I32(value.value(j)));
+                    let value = typed_column::<Int32Array>(column, field_name, "Int32")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::I32(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Int64
                 | prost_reflect::Kind::Sint64
                 | prost_reflect::Kind::Sfixed64 => {
-                    if let Some(value) = column.as_any().downcast_ref::<Int64Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::I64(value.value(j)));
+                    let value = typed_column::<Int64Array>(column, field_name, "Int64")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::I64(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Uint32 | prost_reflect::Kind::Fixed32 => {
-                    if let Some(value) = column.as_any().downcast_ref::<UInt32Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::U32(value.value(j)));
+                    let value = typed_column::<UInt32Array>(column, field_name, "Uint32")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::U32(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Uint64 | prost_reflect::Kind::Fixed64 => {
-                    if let Some(value) = column.as_any().downcast_ref::<UInt64Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::U64(value.value(j)));
+                    let value = typed_column::<UInt64Array>(column, field_name, "Uint64")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::U64(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Float => {
-                    if let Some(value) = column.as_any().downcast_ref::<Float32Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::F32(value.value(j)));
+                    let value = typed_column::<Float32Array>(column, field_name, "Float")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::F32(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::Double => {
-                    if let Some(value) = column.as_any().downcast_ref::<Float64Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(field_name, Value::F64(value.value(j)));
+                    let value = typed_column::<Float64Array>(column, field_name, "Double")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::F64(value.value(j)));
                         }
                     }
                 }
                 prost_reflect::Kind::String => {
-                    if let Some(value) = column.as_any().downcast_ref::<StringArray>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(
-                                    field_name,
-                                    Value::String(value.value(j).to_string()),
-                                );
+                    let value = typed_column::<StringArray>(column, field_name, "String")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(
+                                field_name,
+                                Value::String(value.value(j).to_string()),
+                            );
                         }
                     }
                 }
                 prost_reflect::Kind::Bytes => {
-                    if let Some(value) = column.as_any().downcast_ref::<BinaryArray>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(
-                                    field_name,
-                                    Value::Bytes(value.value(j).to_vec().into()),
-                                );
+                    let value = typed_column::<BinaryArray>(column, field_name, "Bytes")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(
+                                field_name,
+                                Value::Bytes(value.value(j).to_vec().into()),
+                            );
                         }
                     }
                 }
                 prost_reflect::Kind::Enum(_) => {
-                    if let Some(value) = column.as_any().downcast_ref::<Int32Array>() {
-                        for j in 0..value.len() {
-                            if let Some(msg) = vec.get_mut(j) {
-                                msg.set_field_by_name(
-                                    field_name,
-                                    Value::EnumNumber(value.value(j)),
-                                );
+                    let value = typed_column::<Int32Array>(column, field_name, "Enum(Int32)")?;
+                    for j in 0..value.len() {
+                        if let Some(msg) = vec.get_mut(j) {
+                            if value.is_null(j) {
+                                continue;
                             }
+                            msg.set_field_by_name(field_name, Value::EnumNumber(value.value(j)));
                         }
                     }
                 }
                 _ => {
                     return Err(Error::Process(format!(
-                        "Unsupported Protobuf type: {:?}",
+                        "Unsupported Protobuf type for field '{}': kind {:?}",
+                        field_name,
                         proto_field.kind()
-                    )))
+                    )));
                 }
             }
         }
     }
 
-    Ok(vec
-        .into_iter()
+    vec.into_iter()
         .map(|proto_msg| {
             let mut buf = Vec::new();
             proto_msg
@@ -335,5 +410,25 @@ pub fn arrow_to_protobuf(
                 .map_err(|e| Error::Process(format!("Protobuf encoding failed: {}", e)))?;
             Ok(buf)
         })
-        .collect::<Result<Vec<_>, Error>>()?)
+        .collect()
+}
+
+/// Downcast a column to the expected Arrow array type, or return an error naming
+/// the field, the expected proto kind, and the actual Arrow datatype.
+fn typed_column<'a, T: Array + 'static>(
+    column: &'a dyn Array,
+    field_name: &str,
+    expected: &str,
+) -> Result<&'a T, Error> {
+    column
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or_else(|| {
+            Error::Process(format!(
+                "Field '{}' expects proto {} but Arrow column is {:?}",
+                field_name,
+                expected,
+                column.data_type()
+            ))
+        })
 }

--- a/crates/arkflow-plugin/src/processor/protobuf.rs
+++ b/crates/arkflow-plugin/src/processor/protobuf.rs
@@ -14,7 +14,15 @@
 
 //! Protobuf Processor Components
 //!
-//! The processor used to convert between Protobuf data and the Arrow format
+//! The processor used to convert between Protobuf data and the Arrow format.
+//!
+//! # Supported field types
+//!
+//! Scalar proto3 fields are supported: `bool`, `int32`/`sint32`/`sfixed32`,
+//! `int64`/`sint64`/`sfixed64`, `uint32`/`fixed32`, `uint64`/`fixed64`,
+//! `float`, `double`, `string`, `bytes`, and `enum` (mapped to Arrow `Int32`).
+//! Nested message / repeated / map / oneof / proto3 optional fields are NOT
+//! supported and produce an error.
 
 use crate::component::protobuf::{
     arrow_to_protobuf, parse_proto_file, protobuf_to_arrow, ProtobufConfig,
@@ -117,10 +125,6 @@ impl Processor for ProtobufProcessor {
                 Arc::new((*msg).new_binary_with_origin(proto_data)?)
             }
             ToType::ProtobufToArrow(ref c) => {
-                if msg.is_empty() {
-                    return Ok(ProcessResult::None);
-                }
-
                 let mut batches = Vec::with_capacity(msg.len());
                 let result = (*msg).to_binary(
                     c.value_field
@@ -232,7 +236,7 @@ impl ProcessorBuilder for ArrowToProtobufProcessorBuilder {
     }
 }
 
-pub fn init() -> Result<(), Error> {
+pub(crate) fn init() -> Result<(), Error> {
     register_processor_builder(
         "arrow_to_protobuf",
         Arc::new(ArrowToProtobufProcessorBuilder),
@@ -250,7 +254,8 @@ pub fn init() -> Result<(), Error> {
             "properties": {
                 "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type name."},
                 "proto_inputs": {"type": "array", "items": {"type": "string"}, "description": "Paths to .proto files."},
-                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."}
+                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."},
+                "fields_to_include": {"type": "array", "items": {"type": "string"}, "description": "Optional allow-list of field names to include when serializing to Protobuf."}
             },
             "required": ["message_type", "proto_inputs"]
         }),
@@ -264,7 +269,8 @@ pub fn init() -> Result<(), Error> {
             "properties": {
                 "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type name."},
                 "proto_inputs": {"type": "array", "items": {"type": "string"}, "description": "Paths to .proto files."},
-                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."}
+                "proto_includes": {"type": "array", "items": {"type": "string"}, "description": "Include paths for proto resolution."},
+                "value_field": {"type": "string", "description": "Name of the binary column holding the Protobuf wire-format bytes (defaults to '__value')."}
             },
             "required": ["message_type", "proto_inputs"]
         }),
@@ -276,7 +282,9 @@ pub fn init() -> Result<(), Error> {
 mod tests {
     use super::*;
     use arkflow_core::processor::ProcessorBuilder;
-    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
+    use datafusion::arrow::array::{
+        BinaryArray, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray, UInt32Array,
+    };
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use prost_reflect::prost::Message;
@@ -494,5 +502,305 @@ message TestMessage {
             },
         );
         assert!(result.is_ok());
+    }
+
+    fn create_test_proto_file_full() -> Result<(TempDir, PathBuf), Error> {
+        let dir =
+            tempdir().map_err(|e| Error::Process(format!("Failed to create temp dir: {}", e)))?;
+        let proto_dir = dir.path().join("proto");
+        std::fs::create_dir_all(&proto_dir)
+            .map_err(|e| Error::Process(format!("Failed to create proto dir: {}", e)))?;
+        let proto_file_path = proto_dir.join("full_message.proto");
+        std::fs::write(&proto_file_path, r#"syntax = "proto3";
+
+package test;
+
+message FullMessage {
+  int64 timestamp = 1;
+  double value = 2;
+  string sensor = 3;
+  bool active = 4;
+  uint32 count = 5;
+  bytes payload = 6;
+}
+"#)
+        .map_err(|e| Error::Process(format!("Failed to write proto file: {}", e)))?;
+        Ok((dir, proto_dir))
+    }
+
+    fn create_test_proto_file_nested() -> Result<(TempDir, PathBuf), Error> {
+        let dir =
+            tempdir().map_err(|e| Error::Process(format!("Failed to create temp dir: {}", e)))?;
+        let proto_dir = dir.path().join("proto");
+        std::fs::create_dir_all(&proto_dir)
+            .map_err(|e| Error::Process(format!("Failed to create proto dir: {}", e)))?;
+        let proto_file_path = proto_dir.join("nested_message.proto");
+        std::fs::write(&proto_file_path, r#"syntax = "proto3";
+
+package test;
+
+message WithNested {
+  Sub sub = 1;
+}
+
+message Sub {
+  int32 x = 1;
+}
+"#)
+        .map_err(|e| Error::Process(format!("Failed to write proto file: {}", e)))?;
+        Ok((dir, proto_dir))
+    }
+
+    #[tokio::test]
+    async fn test_arrow_to_protobuf_full_scalar_round_trip() -> Result<(), Error> {
+        let (_x, proto_dir) = create_test_proto_file_full()?;
+        let config = ArrowToProtobufProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.FullMessage".to_string(),
+            },
+            fields_to_include: None,
+        };
+        let processor = ProtobufProcessor::new(config.into())?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("sensor", DataType::Utf8, false),
+            Field::new("active", DataType::Boolean, false),
+            Field::new("count", DataType::UInt32, false),
+            Field::new("payload", DataType::Binary, false),
+        ]));
+        let rb = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1634567890])),
+                Arc::new(Float64Array::from(vec![42.5])),
+                Arc::new(StringArray::from(vec!["temperature"])),
+                Arc::new(BooleanArray::from(vec![true])),
+                Arc::new(UInt32Array::from(vec![7u32])),
+                Arc::new(BinaryArray::from(vec![b"\x01\x02".as_ref()])),
+            ],
+        )
+        .map_err(|e| Error::Process(format!("Failed to create record batch: {}", e)))?;
+        let msg_batch = MessageBatch::new_arrow(rb);
+
+        let result = processor.process(Arc::new(msg_batch)).await?;
+        let batch = match result {
+            ProcessResult::Single(b) => b,
+            _ => panic!("Expected single result"),
+        };
+        let data = batch.to_binary(DEFAULT_BINARY_VALUE_FIELD)?;
+        let decoded =
+            DynamicMessage::decode(processor.descriptor.clone(), data[0].as_ref())
+                .map_err(|e| Error::Process(format!("Failed to decode: {}", e)))?;
+        assert_eq!(decoded.get_field_by_name("timestamp").unwrap().as_ref(), &Value::I64(1634567890));
+        assert_eq!(decoded.get_field_by_name("value").unwrap().as_ref(), &Value::F64(42.5));
+        assert_eq!(decoded.get_field_by_name("active").unwrap().as_ref(), &Value::Bool(true));
+        assert_eq!(decoded.get_field_by_name("count").unwrap().as_ref(), &Value::U32(7));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_type_mismatch_errors() {
+        // An Arrow Int32 column for a proto int64 field must error, not silently drop the field.
+        let (_x, proto_dir) = create_test_proto_file_full().unwrap();
+        let config = ArrowToProtobufProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.FullMessage".to_string(),
+            },
+            fields_to_include: None,
+        };
+        let processor = ProtobufProcessor::new(config.into()).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("timestamp", DataType::Int32, false)]));
+        let rb = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1]))]).unwrap();
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await;
+        assert!(
+            result.is_err(),
+            "Int32 column for proto int64 field must error, not silently drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_absent_field_concat_succeeds() -> Result<(), Error> {
+        // Two messages, A with all fields set, B with some unset — concat must not fail
+        // because the schema is descriptor-driven (all fields nullable).
+        let (_x, proto_dir) = create_test_proto_file()?;
+        let config = ProtobufToArrowProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.TestMessage".to_string(),
+            },
+            value_field: None,
+        };
+        let processor = ProtobufProcessor::new(config.into())?;
+        let d = processor.descriptor.clone();
+
+        let mut a = DynamicMessage::new(d.clone());
+        a.set_field_by_name("timestamp", Value::I64(1));
+        a.set_field_by_name("value", Value::F64(1.0));
+        a.set_field_by_name("sensor", Value::String("s".to_string()));
+
+        let mut b = DynamicMessage::new(d.clone());
+        b.set_field_by_name("timestamp", Value::I64(2));
+        // b.value and b.sensor intentionally unset
+
+        let mut ea = Vec::new();
+        a.encode(&mut ea).map_err(|e| Error::Process(format!("encode: {}", e)))?;
+        let mut eb = Vec::new();
+        b.encode(&mut eb).map_err(|e| Error::Process(format!("encode: {}", e)))?;
+        let msg_batch = MessageBatch::new_binary(vec![ea, eb])?;
+
+        let result = processor.process(Arc::new(msg_batch)).await?;
+        let batch = match result {
+            ProcessResult::Single(b) => b,
+            _ => panic!("Expected single result"),
+        };
+        assert_eq!(batch.len(), 2);
+        // sensor column must exist (descriptor-driven) even though message B lacks it.
+        assert!(batch.schema().field_with_name("sensor").is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_null_arrow_value_left_unset() -> Result<(), Error> {
+        let (_x, proto_dir) = create_test_proto_file()?;
+        let config = ArrowToProtobufProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.TestMessage".to_string(),
+            },
+            fields_to_include: None,
+        };
+        let processor = ProtobufProcessor::new(config.into())?;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, true),
+            Field::new("value", DataType::Float64, true),
+            Field::new("sensor", DataType::Utf8, true),
+        ]));
+        let rb = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), None])),
+                Arc::new(Float64Array::from(vec![Some(1.0), None])),
+                Arc::new(StringArray::from(vec![Some("a"), None])),
+            ],
+        )
+        .map_err(|e| Error::Process(format!("Failed to create record batch: {}", e)))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        let batch = match result {
+            ProcessResult::Single(b) => b,
+            _ => panic!("Expected single result"),
+        };
+        let data = batch.to_binary(DEFAULT_BINARY_VALUE_FIELD)?;
+        // Row 1 (all null) → fields unset → decoded message has no timestamp field.
+        let decoded =
+            DynamicMessage::decode(processor.descriptor.clone(), data[1].as_ref())
+                .map_err(|e| Error::Process(format!("Failed to decode: {}", e)))?;
+        // proto3 does not distinguish unset from default on the wire; assert the null row
+        // decodes to the default (0) and never carries another row's value.
+        let ts = decoded.get_field_by_name("timestamp");
+        let is_default = match &ts {
+            None => true,
+            Some(c) => matches!(c.as_ref(), Value::I64(0)),
+        };
+        assert!(
+            is_default,
+            "null Arrow value must decode to the proto default, got {:?}",
+            ts
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fields_to_include_filters() -> Result<(), Error> {
+        let (_x, proto_dir) = create_test_proto_file()?;
+        let mut include = HashSet::new();
+        include.insert("timestamp".to_string());
+        let config = ArrowToProtobufProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.TestMessage".to_string(),
+            },
+            fields_to_include: Some(include),
+        };
+        let processor = ProtobufProcessor::new(config.into())?;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("sensor", DataType::Utf8, false),
+        ]));
+        let rb = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![42])),
+                Arc::new(Float64Array::from(vec![1.0])),
+                Arc::new(StringArray::from(vec!["s"])),
+            ],
+        )
+        .map_err(|e| Error::Process(format!("Failed to create record batch: {}", e)))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        let batch = match result {
+            ProcessResult::Single(b) => b,
+            _ => panic!("Expected single result"),
+        };
+        let data = batch.to_binary(DEFAULT_BINARY_VALUE_FIELD)?;
+        let decoded =
+            DynamicMessage::decode(processor.descriptor.clone(), data[0].as_ref())
+                .map_err(|e| Error::Process(format!("Failed to decode: {}", e)))?;
+        assert_eq!(decoded.get_field_by_name("timestamp").unwrap().as_ref(), &Value::I64(42));
+        // value/sensor were filtered out of the Arrow batch, so they must not carry
+        // the originally-passed values.
+        let value = decoded.get_field_by_name("value");
+        let encoded_value = match &value {
+            None => false,
+            Some(c) => matches!(c.as_ref(), Value::F64(1.0)),
+        };
+        assert!(
+            !encoded_value,
+            "filtered-out field 'value' must not be encoded, got {:?}",
+            value
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_nested_field_errors() -> Result<(), Error> {
+        // A nested-message field is unsupported and must error, naming the kind.
+        let (_x, proto_dir) = create_test_proto_file_nested()?;
+        let config = ProtobufToArrowProcessorConfig {
+            c: CommonProtobufProcessorConfig {
+                proto_inputs: vec![proto_dir.to_string_lossy().to_string()],
+                proto_includes: None,
+                message_type: "test.WithNested".to_string(),
+            },
+            value_field: None,
+        };
+        let processor = ProtobufProcessor::new(config.into())?;
+        let msg = DynamicMessage::new(processor.descriptor.clone());
+        let mut buf = Vec::new();
+        msg.encode(&mut buf)
+            .map_err(|e| Error::Process(format!("encode: {}", e)))?;
+        let msg_batch = MessageBatch::new_binary(vec![buf])?;
+        let result = processor.process(Arc::new(msg_batch)).await;
+        let err = result.err().expect("nested field must error");
+        assert!(
+            format!("{:?}", err).to_lowercase().contains("kind"),
+            "error should mention field kind, got: {:?}",
+            err
+        );
+        Ok(())
     }
 }

--- a/crates/arkflow-plugin/src/processor/vrl.rs
+++ b/crates/arkflow-plugin/src/processor/vrl.rs
@@ -13,7 +13,7 @@ use datafusion::parquet::data_type::AsBytes;
 use duckdb::arrow::datatypes::FieldRef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
+use tracing::{error, warn};
 use vrl::prelude::ObjectMap;
 use vrl::{
     compiler::{self, Program, TargetValue, TimeZone},
@@ -31,24 +31,28 @@ pub fn init() -> Result<(), Error> {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "statement": {"type": "string", "description": "VRL program source."}
+                "statement": {"type": "string", "description": "VRL program source."},
+                "timezone": {"type": "string", "description": "Optional timezone for VRL timestamp operations (e.g. 'Asia/Shanghai', 'UTC', 'local'). Defaults to the platform local timezone; invalid values fall back to the default with a warning."}
             },
             "required": ["statement"]
         }),
-    ).with_example(serde_json::json!({
+    )
+    .with_example(serde_json::json!({
         "statement": ".message = parse_json!(.message)\n.timestamp = now()"
-    })))
+    })))?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct VrlProcessorConfig {
     statement: String,
+    #[serde(default)]
+    timezone: Option<String>,
 }
 
 struct VrlProcessor {
-    #[allow(unused)]
-    config: VrlProcessorConfig,
     program: Program,
+    timezone: TimeZone,
 }
 
 #[async_trait]
@@ -57,7 +61,7 @@ impl Processor for VrlProcessor {
         let result = message_batch_to_vrl_values((*msg_batch).clone());
 
         let mut state = RuntimeState::default();
-        let timezone = TimeZone::default();
+        let timezone = self.timezone;
         let mut output: Vec<Vec<VrlValue>> = Vec::with_capacity(result.len());
 
         for x in result {
@@ -70,19 +74,20 @@ impl Processor for VrlProcessor {
             };
 
             let mut ctx = Context::new(&mut target, &mut state, &timezone);
-            if let Ok(v) = self.program.resolve(&mut ctx) {
-                match v {
-                    VrlValue::Array(vv) => {
-                        output.push(vv);
-                    }
-                    _ => output.push(vec![v]),
-                }
+            // D2: surface runtime errors instead of silently dropping the batch.
+            let v = self.program.resolve(&mut ctx).map_err(|e| {
+                error!("VRL statement evaluation failed: {:?}", e);
+                Error::Process(format!("VRL statement evaluation failed: {:?}", e))
+            })?;
+            match v {
+                VrlValue::Array(vv) => output.push(vv),
+                _ => output.push(vec![v]),
             }
         }
 
         let batches = output
             .into_iter()
-            .map(|x| vrl_values_to_message_batch(x))
+            .map(vrl_values_to_message_batch)
             .collect::<Result<Vec<MessageBatch>, Error>>()?;
 
         // Convert to ProcessResult
@@ -114,18 +119,33 @@ impl ProcessorBuilder for VrlProcessorBuilder {
     ) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {
             return Err(Error::Config(
-                "JsonToArrow processor configuration is missing".to_string(),
+                "VRL processor configuration is missing".to_string(),
             ));
         }
         let vrl_config: VrlProcessorConfig = serde_json::from_value(config.clone().unwrap())?;
+
+        // D5: optional timezone; fall back to the default on invalid input.
+        let timezone = match vrl_config.timezone.as_deref() {
+            Some(tz) => match TimeZone::parse(tz) {
+                Some(t) => t,
+                None => {
+                    warn!(
+                        "Invalid VRL timezone '{}'; falling back to the default timezone.",
+                        tz
+                    );
+                    TimeZone::default()
+                }
+            },
+            None => TimeZone::default(),
+        };
 
         let fns = stdlib::all();
         let result = compiler::compile(&vrl_config.statement, &fns)
             .map_err(|e| Error::Config(format!("Failed to compile VRL statement: {:?}", e)))?;
 
         Ok(Arc::new(VrlProcessor {
-            config: vrl_config,
             program: result.program,
+            timezone,
         }))
     }
 }
@@ -290,13 +310,34 @@ fn message_batch_to_vrl_values(message_batch: MessageBatch) -> Vec<VrlValue> {
                     insert(i, &mut vrl_values, name, vrl_value)
                 }
             }
-            DataType::Timestamp(_unit, _tz) => {
-                if let Some(col) = column.as_any().downcast_ref::<TimestampNanosecondArray>() {
-                    for i in 0..rows {
-                        let value = col.value_as_datetime(i).unwrap_or_default();
-
-                        let vrl_value = VrlValue::Timestamp(value.and_utc());
-                        insert(i, &mut vrl_values, name, vrl_value);
+            DataType::Timestamp(unit, _tz) => {
+                // D3: honor the Arrow time unit instead of only Nanosecond.
+                for i in 0..rows {
+                    let dt = match unit {
+                        TimeUnit::Second => column
+                            .as_any()
+                            .downcast_ref::<TimestampSecondArray>()
+                            .and_then(|c| c.value_as_datetime(i)),
+                        TimeUnit::Millisecond => column
+                            .as_any()
+                            .downcast_ref::<TimestampMillisecondArray>()
+                            .and_then(|c| c.value_as_datetime(i)),
+                        TimeUnit::Microsecond => column
+                            .as_any()
+                            .downcast_ref::<TimestampMicrosecondArray>()
+                            .and_then(|c| c.value_as_datetime(i)),
+                        TimeUnit::Nanosecond => column
+                            .as_any()
+                            .downcast_ref::<TimestampNanosecondArray>()
+                            .and_then(|c| c.value_as_datetime(i)),
+                    };
+                    match dt {
+                        // D3: a missing/unconvertible timestamp is Null, not epoch.
+                        Some(value) => {
+                            let vrl_value = VrlValue::Timestamp(value.and_utc());
+                            insert(i, &mut vrl_values, name, vrl_value);
+                        }
+                        None => insert(i, &mut vrl_values, name, VrlValue::Null),
                     }
                 }
             }
@@ -315,26 +356,36 @@ fn message_batch_to_vrl_values(message_batch: MessageBatch) -> Vec<VrlValue> {
 }
 
 fn vrl_values_to_message_batch(mut vrl_values: Vec<VrlValue>) -> Result<MessageBatch, Error> {
-    let Some(first_value) = vrl_values.first() else {
-        return Ok(MessageBatch::from(RecordBatch::new_empty(Arc::new(
-            Schema::empty(),
-        ))));
-    };
-
-    let fields = match first_value {
-        VrlValue::Object(obj) => obj
-            .iter()
-            .map(|(k, v)| match get_arrow_data_type(v) {
-                Ok(data_type) => Ok(FieldRef::new(Field::new(k.to_string(), data_type, true))),
-                Err(e) => Err(e),
-            })
-            .collect::<Result<Vec<FieldRef>, Error>>()?,
-        _ => {
+    let first_value = match vrl_values.first() {
+        Some(v) => v,
+        None => {
             return Ok(MessageBatch::from(RecordBatch::new_empty(Arc::new(
                 Schema::empty(),
             ))));
         }
     };
+
+    // D4: a non-object result (scalar, etc.) is an error, not a silent empty batch.
+    let first_obj = match first_value {
+        VrlValue::Object(obj) => obj,
+        other => {
+            return Err(Error::Process(format!(
+                "VRL statement must return a row object (or an array of row objects) per row; got {}",
+                other.kind_str()
+            )));
+        }
+    };
+
+    let fields = first_obj
+        .iter()
+        .map(|(k, v)| {
+            let field_name = k.to_string();
+            match get_arrow_data_type(v, field_name.as_str(), &vrl_values) {
+                Ok(data_type) => Ok(FieldRef::new(Field::new(field_name, data_type, true))),
+                Err(e) => Err(e),
+            }
+        })
+        .collect::<Result<Vec<FieldRef>, Error>>()?;
 
     let mut cols: Vec<ArrayRef> = Vec::with_capacity(fields.len());
     for field in fields.iter() {
@@ -398,9 +449,7 @@ fn vrl_values_to_message_batch(mut vrl_values: Vec<VrlValue>) -> Result<MessageB
                     match vrl_value {
                         VrlValue::Object(obj) => {
                             if let Some(VrlValue::Timestamp(v)) = obj.remove(field_name.as_str()) {
-                                cols.push(
-                                    v.timestamp_nanos_opt().map_or_else(|| None, |v| Some(v)),
-                                );
+                                cols.push(v.timestamp_nanos_opt());
                             } else {
                                 cols.push(None)
                             }
@@ -409,6 +458,27 @@ fn vrl_values_to_message_batch(mut vrl_values: Vec<VrlValue>) -> Result<MessageB
                     }
                 }
                 Arc::new(TimestampNanosecondArray::from(cols))
+            }
+
+            // D1: a string column stays a string column.
+            DataType::Utf8 => {
+                let mut col_vals: Vec<Option<String>> = Vec::with_capacity(vrl_values.len());
+                for vrl_value in vrl_values.iter_mut() {
+                    match vrl_value {
+                        VrlValue::Object(obj) => {
+                            if let Some(VrlValue::Bytes(v)) = obj.remove(field_name.as_str()) {
+                                match std::str::from_utf8(v.as_bytes()) {
+                                    Ok(s) => col_vals.push(Some(s.to_owned())),
+                                    Err(_) => col_vals.push(None),
+                                }
+                            } else {
+                                col_vals.push(None);
+                            }
+                        }
+                        _ => col_vals.push(None),
+                    }
+                }
+                Arc::new(StringArray::from(col_vals))
             }
 
             DataType::Binary => {
@@ -449,14 +519,237 @@ fn insert(i: usize, vrl_values: &mut Vec<ObjectMap>, name: &str, val: VrlValue) 
     }
 }
 
-fn get_arrow_data_type(val: &VrlValue) -> Result<DataType, Error> {
+fn get_arrow_data_type(val: &VrlValue, field: &str, all: &[VrlValue]) -> Result<DataType, Error> {
     match val {
-        VrlValue::Bytes(_) => Ok(DataType::Binary),
+        // D1: emit Utf8 when every value in this column is valid UTF-8, else Binary.
+        VrlValue::Bytes(_) => {
+            let mut all_utf8 = true;
+            for v in all {
+                let fv = match v {
+                    VrlValue::Object(o) => o.get(field),
+                    _ => None,
+                };
+                if let Some(VrlValue::Bytes(b)) = fv {
+                    if std::str::from_utf8(b.as_bytes()).is_err() {
+                        all_utf8 = false;
+                        break;
+                    }
+                }
+            }
+            if all_utf8 {
+                Ok(DataType::Utf8)
+            } else {
+                Ok(DataType::Binary)
+            }
+        }
         VrlValue::Integer(_) => Ok(DataType::Int64),
         VrlValue::Float(_) => Ok(DataType::Float64),
         VrlValue::Boolean(_) => Ok(DataType::Boolean),
         VrlValue::Timestamp(_) => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         VrlValue::Null => Ok(DataType::Null),
-        _ => Err(Error::Config("Unsupported data type".to_string())),
+        VrlValue::Object(_) | VrlValue::Array(_) => Err(Error::Process(format!(
+            "VRL returned a nested {} for field '{}'; nested objects/arrays are not supported as column values",
+            val.kind_str(),
+            field
+        ))),
+        _ => Err(Error::Process(format!(
+            "VRL returned an unsupported value type ({}) for field '{}'",
+            val.kind_str(),
+            field
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use serde_json::json;
+    use std::cell::RefCell;
+
+    fn test_resource() -> Resource {
+        Resource {
+            temporary: Default::default(),
+            input_names: RefCell::new(Default::default()),
+        }
+    }
+
+    fn build_processor(statement: &str) -> Result<Arc<dyn Processor>, Error> {
+        let config = Some(json!({ "statement": statement }));
+        VrlProcessorBuilder.build(None, &config, &test_resource())
+    }
+
+    #[tokio::test]
+    async fn test_string_roundtrip_stays_utf8() -> Result<(), Error> {
+        let processor = build_processor(".")?;
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let arr = Arc::new(StringArray::from(vec![Some("alice")]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        match result {
+            ProcessResult::Single(b) => {
+                assert_eq!(
+                    b.column(0).data_type(),
+                    &DataType::Utf8,
+                    "string column must stay Utf8 after VRL"
+                );
+                let col = b
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8 column");
+                assert_eq!(col.value(0), "alice");
+            }
+            _ => panic!("expected single result"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_binary_stays_binary() -> Result<(), Error> {
+        let processor = build_processor(".")?;
+        let bad: Vec<u8> = vec![0xFF, 0xFE, 0xFD];
+        let schema = Arc::new(Schema::new(vec![Field::new("data", DataType::Binary, true)]));
+        let arr = Arc::new(BinaryArray::from(vec![Some(bad.as_slice())]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        match result {
+            ProcessResult::Single(b) => {
+                assert_eq!(
+                    b.column(0).data_type(),
+                    &DataType::Binary,
+                    "non-UTF-8 bytes must stay Binary"
+                );
+            }
+            _ => panic!("expected single result"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_integer_roundtrip() -> Result<(), Error> {
+        let processor = build_processor(".")?;
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, true)]));
+        let arr = Arc::new(Int64Array::from(vec![Some(1)]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        match result {
+            ProcessResult::Single(b) => {
+                assert_eq!(b.column(0).data_type(), &DataType::Int64);
+            }
+            _ => panic!("expected single result"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_runtime_error_returns_err() -> Result<(), Error> {
+        // parse_json! is fallible; on bad input the processor must surface an error,
+        // not silently drop the batch.
+        let processor = build_processor("parse_json!(.message)")?;
+        let schema = Arc::new(Schema::new(vec![Field::new("message", DataType::Utf8, true)]));
+        let arr = Arc::new(StringArray::from(vec![Some("not json")]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await;
+        assert!(
+            result.is_err(),
+            "a failing VRL statement must return Err, not silently drop the batch"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scalar_result_returns_err() -> Result<(), Error> {
+        // A scalar result cannot form a row; it must error rather than produce an empty batch.
+        let processor = build_processor("1 + 1")?;
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let arr = Arc::new(StringArray::from(vec![Some("alice")]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await;
+        assert!(
+            result.is_err(),
+            "a scalar VRL result must error, not produce an empty batch"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_empty_batch_returns_none() -> Result<(), Error> {
+        let processor = build_processor(".")?;
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let arr = Arc::new(StringArray::from(Vec::<Option<&str>>::new()));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        assert!(matches!(result, ProcessResult::None));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_second_not_dropped() -> Result<(), Error> {
+        // D3: a Second-precision timestamp column must reach the VRL program (not be dropped).
+        let processor = build_processor(".")?;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        )]));
+        let arr = Arc::new(TimestampSecondArray::from(vec![Some(1_000_000i64)]));
+        let rb = RecordBatch::try_new(schema, vec![arr])
+            .map_err(|e| Error::Process(format!("arrow: {e}")))?;
+        let result = processor
+            .process(Arc::new(MessageBatch::new_arrow(rb)))
+            .await?;
+        match result {
+            ProcessResult::Single(b) => {
+                assert!(
+                    b.schema().field_with_name("ts").is_ok(),
+                    "ts field must survive a Second-precision timestamp round-trip"
+                );
+            }
+            _ => panic!("expected single result"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_compile_error_rejected() {
+        let config = Some(json!({ "statement": "this is not valid vrl !!!" }));
+        let result = VrlProcessorBuilder.build(None, &config, &test_resource());
+        assert!(result.is_err(), "an invalid VRL statement must be rejected at build time");
+    }
+
+    #[test]
+    fn test_timezone_config_accepted() {
+        let config = Some(json!({ "statement": ".x = 1", "timezone": "Asia/Shanghai" }));
+        let result = VrlProcessorBuilder.build(None, &config, &test_resource());
+        assert!(result.is_ok(), "a valid timezone config should build successfully");
+    }
+
+    #[test]
+    fn test_invalid_timezone_falls_back() {
+        let config = Some(json!({ "statement": ".x = 1", "timezone": "Not/A_Real_Zone" }));
+        let result = VrlProcessorBuilder.build(None, &config, &test_resource());
+        assert!(
+            result.is_ok(),
+            "an invalid timezone should fall back to the default, not fail configuration"
+        );
     }
 }

--- a/openspec/changes/archive/2026-07-26-harden-protobuf-codec/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-harden-protobuf-codec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-harden-protobuf-codec/design.md
+++ b/openspec/changes/archive/2026-07-26-harden-protobuf-codec/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Protobuf conversion lives in `component/protobuf.rs` (`protobuf_to_arrow`, `arrow_to_protobuf`), shared by the processor (`processor/protobuf.rs`) and codec (`codec/protobuf.rs`). Two directions:
+
+- `arrow_to_protobuf`: iterate Arrow columns, downcast to the array type matching each proto field's `Kind`, set the field on a `DynamicMessage` per row, encode.
+- `protobuf_to_arrow`: decode one message, iterate its fields, build a 1-row `RecordBatch`. Callers concat the per-message batches.
+
+The concat step assumes every per-message batch shares one schema, but the code skips absent fields, breaking that assumption. The downcast step assumes the Arrow type always matches the proto `Kind`, and silently drops the field when it doesn't.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A type-mismatched column errors loudly instead of disappearing.
+- Every decoded message produces the same schema (descriptor-driven, all fields nullable), so `concat_batches` always succeeds.
+- Null Arrow values map to "unset proto field", not "proto default".
+- The metadata schema matches the runtime's real config fields.
+- Tests pin the round-trip and every edge.
+
+**Non-Goals:**
+- Supporting nested / repeated / map / oneof / optional fields (document + error only).
+- Crate upgrades.
+
+## Decisions
+
+### D1 — Type mismatch is an error, not a silent skip
+Replace each `if let Some(value) = column.downcast_ref::<XxxArray>() { ... }` with `downcast_ref::<...>().ok_or_else(|| Error::Process(...))?` naming the field, the expected proto `Kind`, and the actual Arrow `DataType`. A field that can't be converted is a configuration/data bug the user must hear about.
+
+**Alternative considered:** *Coerce where possible (Int32→Int64).* Rejected — silent coercion hides data-shape bugs and has no correct bidirectional answer. Error and let the user cast explicitly upstream.
+
+### D2 — Descriptor-driven stable schema in `protobuf_to_arrow`
+Iterate `descriptor.fields()` (not the message's present fields) and build every column as nullable. An absent field value becomes a null in that column. Every message therefore yields an identical schema and `concat_batches` cannot fail on shape. This also removes the `if field_value_opt.is_none() { continue }` skip (`component/protobuf.rs:133-135`).
+
+### D3 — Null Arrow values are left unset
+In `arrow_to_protobuf`, check `column.is_null(j)` before `value.value(j)`; a null skips `set_field_by_name`, leaving the proto field unset (proto3's semantics for "absent"). This differs from today, which reads the default through the validity bitmap and explicitly sets the default.
+
+### D4 — Richer unsupported-type errors
+The `_ => Err(...)` arms include `field.kind()` (and the field name) so the message identifies the offending type.
+
+### D5 — Metadata schema matches runtime
+Add `fields_to_include` to the `arrow_to_protobuf` schema and `value_field` to the `protobuf_to_arrow` schema, keeping `additionalProperties: false`. Validated via `arkflow components show`.
+
+### D6 — Document the field-type matrix
+A short table in each module doc listing supported scalar `Kind`s and explicitly listing nested / repeated / map / oneof / optional as unsupported.
+
+## Risks / Trade-offs
+
+- **Type-mismatch errors may surface pre-existing bad pipelines** → this is the intended fix; users get a clear message instead of silently wrong data.
+- **Descriptor-driven schema adds null columns for absent fields** → strictly more correct; downstream SQL/JSON already handle nullable columns.
+- **Null→unset changes wire bytes** → proto3 doesn't serialize unset fields, so messages get smaller/cleaner; read-back value is unchanged (default).
+
+## Migration Plan
+
+1. D1 + D3 in `arrow_to_protobuf`; D2 + D4 in `protobuf_to_arrow`.
+2. D5 metadata; D6 docs.
+3. Cleanups (dead code, visibility, import, clippy).
+4. Tests; `cargo test -p arkflow-plugin` green.
+5. Rollback: revert the three files; no schema/trait change to undo.

--- a/openspec/changes/archive/2026-07-26-harden-protobuf-codec/proposal.md
+++ b/openspec/changes/archive/2026-07-26-harden-protobuf-codec/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The protobuf processor/codec (`component/protobuf.rs`, `processor/protobuf.rs`, `codec/protobuf.rs`) silently drops data and rejects valid configs:
+
+- **Type-mismatched fields are silently dropped.** `arrow_to_protobuf` downcasts each Arrow column to the proto field's expected array type via `if let Some(...)`, so a mismatch (e.g. Arrow `Int32` column for a proto `int64` field) makes the downcast return `None` and the field is skipped with no error or log (`component/protobuf.rs:215-326`).
+- **concat_batches fails at runtime on optional fields.** `protobuf_to_arrow` skips any field whose value is absent (`component/protobuf.rs:133-135`), so two messages with different fields present produce different schemas and `concat_batches` later fails with only "Batch merge failed" (`processor/protobuf.rs:136-138`, `codec/protobuf.rs:105-107`).
+- **Null Arrow values are silently encoded as proto defaults.** `arrow_to_protobuf` reads `value.value(j)` ignoring the validity bitmap, so a null row becomes `false`/`0`/`""` in the encoded message (`component/protobuf.rs:217-318`).
+- **Valid configs are rejected by the schema.** The component metadata JSON Schema omits `fields_to_include` (arrow_to_protobuf) and `value_field` (protobuf_to_arrow) while setting `additionalProperties: false`, so the IDE YAML server and `arkflow schema` reject configs the runtime accepts (`processor/protobuf.rs:244-271`).
+- **No codec round-trip tests.** The codec's tests cover only config deserialization; there is no encode→decode round-trip, and `fields_to_include` / `value_field` / non-happy-path types are untested.
+
+## What Changes
+
+- **FIX**: A type mismatch between an Arrow column and its proto field SHALL return an error naming both types, not silently skip the field (`component/protobuf.rs:215-326`).
+- **FIX**: `protobuf_to_arrow` SHALL build a stable schema from the descriptor's full field set (all fields nullable), so every message yields the same schema and `concat_batches` no longer fails on optional/absent fields (`component/protobuf.rs:116-191`).
+- **FIX**: Null Arrow values SHALL be left unset in the encoded proto message (not silently coerced to the proto default) (`component/protobuf.rs:217-318`).
+- **FIX**: Unsupported-field errors SHALL include `field.kind()` so users can see why a type is unsupported (`component/protobuf.rs:178-183, 319-324`).
+- **FIX**: The component metadata JSON Schema SHALL declare `fields_to_include` and `value_field` so valid configs pass schema validation (`processor/protobuf.rs:244-271`).
+- **CLEANUP**: Remove dead code, fix inconsistent `init()` visibility, drop the redundant `use serde_json;`, and clear the clippy warnings (`map_or(false,..)`→`is_some_and`, `.clone()` on `Copy` types, redundant `Ok(..)?`).
+- **NEW**: Tests — codec encode/decode round-trip, `fields_to_include`, `value_field`, full scalar type coverage (bool/bytes/enum/uint32/uint64/float32 in addition to int64/double/string), the unsupported-type error path, and the null-value path.
+- **DOCS**: Document the supported/unsupported field-type matrix (scalar fields supported; nested message, repeated, map, oneof, proto3 optional are NOT supported) in module docs.
+
+No **BREAKING** public API changes.
+
+## Non-goals
+
+- **Adding support for nested message / repeated / map / oneof / proto3 optional fields** — out of scope; this change only documents the limitation and errors clearly when such a field is encountered.
+- **Protobuf/prost-reflect crate version upgrade** — separate change.
+
+## Capabilities
+
+### New Capabilities
+- `protobuf-codec`: The protobuf processor/codec's data-correctness contracts — no silent field drops, stable schemas for concat, explicit null handling, schema-valid metadata, and the test coverage that pins them.
+
+### Modified Capabilities
+<!-- None — there is no existing openspec/specs/protobuf-codec spec today. -->
+
+## Impact
+
+- **`arkflow-plugin`**: `component/protobuf.rs` (core conversion), `processor/protobuf.rs` (metadata schema + dead code), `codec/protobuf.rs` (visibility + import).
+- **Dependencies**: None added or upgraded.
+- **Behavioral**: Type mismatches now error instead of silently dropping fields; optional/absent proto fields no longer break concat; null Arrow values are left unset rather than coerced to defaults. These are correctness fixes, not API breaks.
+- **Tests**: New round-trip and edge-case tests.

--- a/openspec/changes/archive/2026-07-26-harden-protobuf-codec/specs/protobuf-codec/spec.md
+++ b/openspec/changes/archive/2026-07-26-harden-protobuf-codec/specs/protobuf-codec/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Type-mismatched fields error instead of silently dropping
+When an Arrow column's datatype does not match the proto field's `Kind` during `arrow_to_protobuf`, the processor/codec SHALL return an error naming the field, the expected proto kind, and the actual Arrow datatype. It SHALL NOT silently skip the field.
+
+#### Scenario: Mismatched integer width surfaces an error
+- **WHEN** an Arrow `Int32` column is encoded into a proto `int64` field
+- **THEN** the conversion returns an `Err` naming the field and both types, rather than silently omitting the field
+
+### Requirement: Decoded messages share a stable schema
+`protobuf_to_arrow` SHALL build its schema from the message descriptor's full field set with every field nullable, so every decoded message yields the same schema regardless of which fields are present. Concatenating per-message batches SHALL NOT fail with a schema mismatch.
+
+#### Scenario: Absent field does not break concat
+- **WHEN** message A has field `b` set and message B does not
+- **THEN** both decode to the same schema (field `b` present, nullable), and concatenating the two batches succeeds with a null in B's `b` column
+
+### Requirement: Null Arrow values map to the proto field's absence
+During `arrow_to_protobuf`, a null Arrow value SHALL NOT be explicitly written into the encoded proto message; the field is left absent (which in proto3 reads back as the default value), rather than being read through the validity bitmap and explicitly set.
+
+#### Scenario: Null row does not carry another row's value
+- **WHEN** an Arrow column has a null in row j while another row carries a non-default value
+- **THEN** the encoded proto message for row j decodes to the proto default, never to another row's value
+
+### Requirement: Unsupported field types produce an informative error
+When a proto field uses an unsupported kind (nested message, repeated, map, oneof, proto3 optional), the conversion SHALL return an error that includes the field name and `field.kind()`.
+
+#### Scenario: Nested message field reports its kind
+- **WHEN** a proto field of kind message is encountered during `protobuf_to_arrow`
+- **THEN** the error message names the field and includes its kind
+
+### Requirement: Component metadata schema matches runtime config
+The `arrow_to_protobuf` component metadata JSON Schema SHALL declare `fields_to_include`, and the `protobuf_to_arrow` schema SHALL declare `value_field`. Both schemas retain `additionalProperties: false`, so valid runtime configs pass schema validation.
+
+#### Scenario: fields_to_include passes schema validation
+- **WHEN** the `arrow_to_protobuf` metadata is queried
+- **THEN** `arkflow components show processor arrow_to_protobuf --format json` lists `fields_to_include` in the schema properties
+
+#### Scenario: value_field passes schema validation
+- **WHEN** the `protobuf_to_arrow` metadata is queried
+- **THEN** `arkflow components show processor protobuf_to_arrow --format json` lists `value_field` in the schema properties
+
+### Requirement: Test coverage pins the protobuf round-trip and edge cases
+The protobuf codec/processor SHALL ship tests covering at least: an encode→decode round-trip across all supported scalar types (bool, int32, int64, uint32, uint64, float32, float64, string, bytes, enum), the `fields_to_include` option, the `value_field` option, the unsupported-type error path, and the null-value path.
+
+#### Scenario: Scalar round-trip tests exist
+- **WHEN** `cargo test -p arkflow-plugin protobuf` runs
+- **THEN** encode→decode round-trip tests for every supported scalar type pass

--- a/openspec/changes/archive/2026-07-26-harden-protobuf-codec/tasks.md
+++ b/openspec/changes/archive/2026-07-26-harden-protobuf-codec/tasks.md
@@ -1,0 +1,36 @@
+## 1. arrow_to_protobuf correctness (D1, D3)
+
+- [x] 1.1 Replace each `if let Some(value) = column.downcast_ref::<XxxArray>()` with `downcast_ref::<...>().ok_or_else(...)?` naming the field, expected Kind, and actual DataType → verify: unit test "mismatched Int32→int64 errors"
+- [x] 1.2 Skip `set_field_by_name` when `column.is_null(j)` (null → unset, not default) → verify: unit test "null row leaves field unset"
+
+## 2. protobuf_to_arrow correctness (D2, D4)
+
+- [x] 2.1 Build the schema from `descriptor.fields()` (all nullable) instead of the message's present fields; absent values become null; remove the `is_none() { continue }` skip → verify: unit test "absent field does not break concat"
+- [x] 2.2 Include `field.kind()` in the unsupported-type error messages → verify: unit test "nested message field reports its kind"
+
+## 3. Component metadata schema (D5)
+
+- [x] 3.1 Add `fields_to_include` to the `arrow_to_protobuf` metadata JSON Schema → verify: `arkflow components show processor arrow_to_protobuf --format json`
+- [x] 3.2 Add `value_field` to the `protobuf_to_arrow` metadata JSON Schema → verify: `arkflow components show processor protobuf_to_arrow --format json`
+
+## 4. Cleanups
+
+- [x] 4.1 Remove the redundant empty-check dead code in `processor/protobuf.rs:120-122` → verify: `cargo build -p arkflow-plugin`
+- [x] 4.2 Make `init()` visibility consistent (`pub(crate)`) across codec and processor → verify: `cargo build -p arkflow-plugin`
+- [x] 4.3 Remove the redundant `use serde_json;` in `codec/protobuf.rs:30` → verify: `cargo build -p arkflow-plugin`
+- [x] 4.4 Clear clippy warnings in `component/protobuf.rs` (`map_or(false,..)`→`is_some_and`, `.clone()` on Copy types, redundant `Ok(..)?`) → verify: `cargo clippy -p arkflow-plugin --lib`
+
+## 5. Docs
+
+- [x] 5.1 Add the supported/unsupported field-type matrix to the module docs of `component/protobuf.rs`, `processor/protobuf.rs`, and `codec/protobuf.rs` → verify: doc comment present
+
+## 6. Tests
+
+- [x] 6.1 Add a codec encode→decode round-trip test covering all supported scalar types (bool, int32, int64, uint32, uint64, float32, float64, string, bytes, enum) → verify: `cargo test -p arkflow-plugin protobuf`
+- [x] 6.2 Add tests for `fields_to_include`, `value_field`, the unsupported-type error path, and the null-value path → verify: `cargo test -p arkflow-plugin protobuf`
+
+## 7. Validation
+
+- [x] 7.1 `cargo test -p arkflow-plugin` green → verify: command exit 0
+- [x] 7.2 `cargo clippy -p arkflow-plugin --lib` introduces no new warnings vs. baseline → verify: command output
+- [x] 7.3 `openspec validate harden-protobuf-codec --strict` passes → verify: command exit 0

--- a/openspec/changes/archive/2026-07-26-harden-vrl-processor/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-harden-vrl-processor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-harden-vrl-processor/design.md
+++ b/openspec/changes/archive/2026-07-26-harden-vrl-processor/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The VRL processor (`crates/arkflow-plugin/src/processor/vrl.rs`) wraps Vector's VRL (v0.30). Per batch the flow is:
+
+1. Convert each Arrow column → a VRL `Value` per row (`arrow_to_vrl`, ~`:139-310`).
+2. Run the compiled program against a per-row target object (`process`, ~`:55-90`).
+3. Convert the VRL result objects back → Arrow columns (`vrl_to_arrow`, ~`:313-410`), inferring a schema from the first row (`get_arrow_data_type`, ~`:452-462`).
+
+Three points in this flow silently destroy data (see proposal `## Why`), and there is no `#[cfg(test)]` module. The entire fix surface is a single file; no trait or cross-module change is needed.
+
+Key constraint: VRL's `Value` enum has **no `String` variant** — strings are `Value::Bytes` — so the string/binary ambiguity is inherent to the boundary and must be resolved on the Arrow side.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `Utf8` Arrow column that goes through VRL comes back as `Utf8` (not `Binary`).
+- A failing VRL statement is observable (logged + returned as `Err`), never silently drops a batch.
+- `Second`/`Millisecond`/`Microsecond`/`Nanosecond` timestamp columns all survive the round-trip.
+- Unsupported result shapes fail loudly instead of producing empty/garbled batches.
+- A test module pins every one of the above.
+
+**Non-Goals:**
+- VRL 0.30 → 0.33 upgrade (separate change).
+- Inferring schemas for nested `Object`/`Array` results (only a clear error is required here).
+- Reusing `RuntimeState` across calls / full multi-row schema inference.
+
+## Decisions
+
+### D1 — Resolve the string/binary ambiguity at the Arrow boundary, not in VRL
+
+`Value::Bytes` is the only representation VRL gives us for both text and binary. On the output side, before building an array, inspect the bytes: if `std::str::from_utf8` succeeds for every value in the column, emit `Utf8` (or `LargeUtf8` when the total length warrants it); otherwise emit `Binary`. This keeps string columns as strings while still preserving genuine binary data.
+
+**Alternatives considered:**
+- *Remember the input column's datatype and force it on output.* Rejected — VRL statements legitimately change types (e.g. `parse_json!`), so blindly copying the input type would lie about the result.
+- *Add a config flag `strings_as_binary`.* Rejected — defaults must be correct; the current binary default is itself the bug.
+
+### D2 — Runtime errors return `Err`, routed by the existing pipeline
+
+`Processor::process` already returns `Result<ProcessResult, Error>`. Today the VRL processor discards `resolve()` errors via `if let Ok(v)`. The fix: on `Err`, `tracing::error!` the diagnostic (VRL errors carry good messages) and return `Err(Error::Processor(...))`. The `Stream` already routes a processor `Err` to `error_output` and applies backpressure — no new plumbing. Failing the batch loudly is strictly better than today's silent full-batch drop.
+
+**Why not drop just the bad row:** VRL runs per-batch with one compiled program; isolating per-row failure would require a per-row try/catch around `resolve` plus a partial-result policy — a larger design, deferred.
+
+### D3 — Honor the Arrow `TimeUnit` on input
+
+Dispatch on `DataType::Timestamp(unit, _)` and read the matching concrete array (`TimestampSecondArray` / `TimestampMillisecondArray` / `TimestampMicrosecondArray` / `TimestampNanosecondArray`), converting each to the VRL timestamp via the unit-correct path. Replace `unwrap_or_default()` (which silently returned epoch) with explicit conversion that represents failure as a VRL null rather than 1970.
+
+### D4 — Unsupported result shapes are an error, never an empty batch
+
+Today a scalar result yields an empty batch (`vrl.rs:332-336`) and `Object`/`Array`/`Regex` results make `get_arrow_data_type` fail the whole batch. Decision: a VRL statement that does not yield a row-shaped object (or an array of rows) returns a clear `Err` naming the unsupported shape. This converts silent data loss into an actionable configuration error.
+
+### D5 — `timezone` is additive config, platform-local default
+
+Add `timezone: Option<String>` to the VRL processor config; resolve it via `TimeZone::parse`, falling back to `TimeZone::default()` (VRL's platform-local default) when absent or unparseable (with a `tracing::warn!`). Defaults preserve today's behavior. No breaking change.
+
+## Risks / Trade-offs
+
+- **Behavior change for users relying on the buggy binary output** → strings now come back as strings. This is the intended correctness fix, not an API break; no config compat change.
+- **Failing the whole batch on one bad row (D2)** → coarser than per-row isolation, but strictly better than silent full-batch loss; per-row isolation deferred.
+- **UTF-8 heuristic (D1)** → a column of binary values that happens to be valid UTF-8 is emitted as `Utf8`. Acceptable: such data is by definition valid text, and genuine binary almost never survives a full-column UTF-8 check.
+- **`timezone` parse failure** → fall back to the default timezone with a warning rather than failing config load, so a bad timezone string never blocks startup.
+
+## Migration Plan
+
+1. Apply the four code fixes (D1–D4) and the small cleanups in `vrl.rs`.
+2. Add the optional `timezone` field (D5); existing configs unchanged.
+3. Add the `#[cfg(test)]` module; `cargo test -p arkflow-plugin` green.
+4. Rollback: revert `vrl.rs`; no schema/config/trait change to undo.

--- a/openspec/changes/archive/2026-07-26-harden-vrl-processor/proposal.md
+++ b/openspec/changes/archive/2026-07-26-harden-vrl-processor/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The VRL processor (`crates/arkflow-plugin/src/processor/vrl.rs`) silently corrupts and drops user data in three ways, and has **zero test coverage** — it is the only processor in the plugin crate without tests:
+
+- **String columns don't round-trip.** VRL's `Value` has no `String` variant (strings are `Value::Bytes`), and the output path maps every `Value::Bytes` to `DataType::binary` (`vrl.rs:454`, building only `BinaryArray` at `vrl.rs:414-429`). So any `Utf8` column read in at `vrl.rs:150-157` comes back as a binary column; downstream `arrow_to_json` / SQL see garbled or base64-encoded data.
+- **Runtime errors are silently swallowed.** `program.resolve()` is called as `if let Ok(v) = self.program.resolve(&mut ctx)` (`vrl.rs:73`); an `Err` drops the entire batch with no log and no routing to `error_output`. Ironically the metadata's own recommended example `parse_json!(.message)` (`vrl.rs:39`) is a fallible function whose failure silently loses every row.
+- **Timestamp input only supports nanoseconds.** The time unit `_unit` is ignored and only `TimestampNanosecondArray` is attempted (`vrl.rs:293-302`); `Second` / `Millisecond` / `Microsecond` timestamp columns are silently dropped column-wide.
+
+## What Changes
+
+- **FIX**: String round-trip — when emitting a column from `Value::Bytes`, detect valid UTF-8 and emit `Utf8`/`LargeUtf8` instead of `Binary`, so string columns stay string columns.
+- **FIX**: Runtime error handling — surface `resolve()` errors (log; return `Err`) instead of silently dropping the batch.
+- **FIX**: Timestamp input — honor the Arrow time unit and read `Second`/`Millisecond`/`Microsecond`/`Nanosecond` arrays; stop silently dropping non-nanosecond columns.
+- **FIX**: Copy-paste error message at `vrl.rs:117` ("JsonToArrow processor configuration is missing" → VRL).
+- **FIX**: Remove the unused `config` field suppressed by `#[allow(unused)]` (`vrl.rs:49-50`).
+- **FIX**: Stop silently coercing bad timestamps to epoch via `unwrap_or_default()` (`vrl.rs:296`).
+- **FIX**: Simplify redundant `map_or_else(|| None, |v| Some(v))` to `.map(|v| v)` (`vrl.rs:402`).
+- **FIX**: A scalar VRL result no longer produces an empty batch (silent data loss) (`vrl.rs:332-336`); unsupported result shapes (`Object`/`Array`/`Regex`) return a clear error instead of failing the whole batch silently (`vrl.rs:452-462`).
+- **NEW**: Unit-test coverage — type round-trips (incl. the string case), empty input, runtime-error handling, compile-error handling, and all timestamp units.
+- **NEW (additive config)**: Optional `timezone` field so users are not locked to the hardcoded `TimeZone::default()` (`vrl.rs:60`); defaults to the platform local timezone (today's behavior).
+
+No **BREAKING** public API changes. Configs without the new optional `timezone` field behave exactly as today (with the data-correctness fixes applied).
+
+## Non-goals
+
+- **VRL version upgrade** (0.30 → 0.33.x) — separate change; the API surface shift is non-trivial and unrelated to these correctness fixes.
+- **Full nested `Object`/`Array` schema inference** — out of scope; this change only requires unsupported result shapes to produce a clear error rather than silent data loss.
+- **Stateful `RuntimeState` reuse across `process()` calls** (`vrl.rs:59`) — deferred; needs a thread-safety audit of VRL stdlib state and is orthogonal to the correctness fixes.
+- **First-row-only schema inference rewrite** (`vrl.rs:324-337`) — the immediate requirement is "no silent loss"; a full multi-row inference algorithm is a larger design effort.
+
+## Capabilities
+
+### New Capabilities
+- `vrl-processor`: The VRL processor's data-correctness contracts — type fidelity (strings stay strings), observable runtime errors, full timestamp-unit support, and the test coverage that pins them.
+
+### Modified Capabilities
+<!-- None — there is no existing openspec/specs/vrl-processor spec today. -->
+
+## Impact
+
+- **`arkflow-plugin`**: `crates/arkflow-plugin/src/processor/vrl.rs` is the only source file changed. Optional new `timezone` field on the VRL processor config struct.
+- **Dependencies**: None added or upgraded.
+- **Behavioral**: String columns round-trip as strings (not binary); `resolve()` failures are observable; non-nanosecond timestamp columns are no longer dropped. These are bug fixes against silent data corruption, not API breaks.
+- **Tests**: New `#[cfg(test)]` module in `vrl.rs`.

--- a/openspec/changes/archive/2026-07-26-harden-vrl-processor/specs/vrl-processor/spec.md
+++ b/openspec/changes/archive/2026-07-26-harden-vrl-processor/specs/vrl-processor/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: String columns round-trip as strings
+An Arrow `Utf8`/`LargeUtf8` column processed by the VRL processor SHALL be emitted as a string column on output. A `Value::Bytes` result column SHALL be emitted as `Utf8` when every value in the column is valid UTF-8, and as `Binary` only when at least one value is not valid UTF-8.
+
+#### Scenario: String column stays a string column
+- **WHEN** an input `Utf8` column named `name` with values `["alice", "bob"]` is processed by a passthrough VRL statement
+- **THEN** the output column `name` has Arrow datatype `Utf8` (not `Binary`) and the same values
+
+#### Scenario: Genuine binary stays binary
+- **WHEN** a VRL result column contains bytes that are not valid UTF-8
+- **THEN** the output column is emitted as `Binary`
+
+### Requirement: Runtime errors are observable
+When `program.resolve()` returns an error for a batch, the VRL processor SHALL log the error and return `Err`; it SHALL NOT silently drop the batch.
+
+#### Scenario: A fallible statement that fails surfaces an error
+- **WHEN** a batch is processed with a VRL statement `parse_json!(.message)` and `.message` is not valid JSON
+- **THEN** the processor logs the VRL diagnostic and returns `Err`, and the batch is not silently discarded
+
+### Requirement: All Arrow timestamp units are supported
+The VRL processor SHALL accept Arrow `Timestamp` columns of every time unit — `Second`, `Millisecond`, `Microsecond`, and `Nanosecond` — and SHALL NOT drop a column because of its unit.
+
+#### Scenario: Non-nanosecond timestamp column is preserved
+- **WHEN** an input `Timestamp(Second, _)` column is processed
+- **THEN** the column is read using the second-precision array and reaches the VRL program (it is not dropped)
+
+#### Scenario: Unset timestamp becomes null, not epoch
+- **WHEN** a timestamp value cannot be converted to a VRL timestamp
+- **THEN** it is represented as a VRL null rather than being silently coerced to 1970-01-01
+
+### Requirement: Unsupported result shapes fail loudly
+A VRL result that is not a row object (or array of row objects) — including scalars, nested `Object`, `Array`, and `Regex` — SHALL cause the processor to return a clear error naming the unsupported shape. It SHALL NOT produce an empty batch or silently lose data.
+
+#### Scenario: Scalar result returns an error
+- **WHEN** a VRL statement returns a scalar (e.g. `1 + 1`)
+- **THEN** the processor returns an `Err` describing the unsupported scalar result, rather than an empty batch
+
+### Requirement: Timezone is configurable
+The VRL processor SHALL accept an optional `timezone` configuration field. When absent, it SHALL default to the platform local timezone (VRL's `TimeZone::default()`, which is today's behavior). An invalid timezone string SHALL fall back to the default with a warning rather than failing configuration.
+
+#### Scenario: Default timezone is the platform local timezone
+- **WHEN** a VRL processor is configured without a `timezone` field
+- **THEN** it uses the platform local timezone, matching today's behavior
+
+#### Scenario: Custom timezone is honored
+- **WHEN** a VRL processor is configured with `timezone: "Asia/Shanghai"`
+- **THEN** VRL timestamp operations use that timezone
+
+#### Scenario: Invalid timezone falls back to the default
+- **WHEN** a VRL processor is configured with an unparseable `timezone` string
+- **THEN** configuration does not fail; the processor logs a warning and uses the platform local timezone
+
+### Requirement: Test coverage pins the data-correctness contracts
+The VRL processor SHALL ship a unit-test module covering at least: string round-trip, empty input, a failing runtime statement, a compile-error configuration, and each timestamp unit.
+
+#### Scenario: Type round-trip tests exist
+- **WHEN** `cargo test -p arkflow-plugin` runs
+- **THEN** tests for string, numeric, boolean, and each timestamp-unit round-trips pass

--- a/openspec/changes/archive/2026-07-26-harden-vrl-processor/tasks.md
+++ b/openspec/changes/archive/2026-07-26-harden-vrl-processor/tasks.md
@@ -1,0 +1,41 @@
+## 1. String round-trip fix (D1)
+
+- [x] 1.1 In the output path, when building an array from a `Value::Bytes` column, detect whether every value is valid UTF-8; emit `Utf8` (or `LargeUtf8` when total length warrants) when so, `Binary` otherwise → verify: unit test "string column stays Utf8 after VRL"
+- [x] 1.2 Ensure genuine non-UTF-8 bytes still emit as `Binary` → verify: unit test "binary column stays Binary"
+
+## 2. Runtime error handling (D2)
+
+- [x] 2.1 Replace `if let Ok(v) = self.program.resolve(&mut ctx)` with explicit `match`; on `Err`, `tracing::error!` the diagnostic and return `Err(Error::Processor(...))` → verify: unit test "parse_json!(.message) on bad JSON returns Err and is logged"
+- [x] 2.2 Confirm a successful resolve still produces the batch as today → verify: existing/passthrough unit test passes after change
+
+## 3. Full timestamp-unit support (D3)
+
+- [x] 3.1 Dispatch on `DataType::Timestamp(unit, _)` to the correct concrete array (`TimestampSecondArray` / `MillisecondArray` / `MicrosecondArray` / `NanosecondArray`) instead of only nanoseconds → verify: unit test for each of the four units
+- [x] 3.2 Replace `unwrap_or_default()` epoch coercion with explicit conversion that yields a VRL null on failure → verify: unit test "unset timestamp is null, not 1970"
+
+## 4. Unsupported result shapes error loudly (D4)
+
+- [x] 4.1 Make a scalar VRL result return `Err` instead of an empty batch → verify: unit test "scalar result returns Err"
+- [x] 4.2 Make `Object` / `Array` / `Regex` results return a clear `Err` naming the unsupported shape (instead of failing opaquely or losing data) → verify: unit test
+
+## 5. Small cleanups
+
+- [x] 5.1 Fix the copy-paste error message at `vrl.rs:117` ("JsonToArrow..." → "VRL processor configuration is missing") → verify: `cargo build -p arkflow-plugin` + grep
+- [x] 5.2 Remove the unused `config` field and its `#[allow(unused)]` (`vrl.rs:49-50`) → verify: `cargo build` warning-free for the field
+- [x] 5.3 Simplify redundant `map_or_else(|| None, |v| Some(v))` → `.map(|v| v)` (`vrl.rs:402`) → verify: `cargo build`
+
+## 6. Timezone config (D5)
+
+- [x] 6.1 Add `timezone: Option<String>` to the VRL processor config; resolve at build time, defaulting to UTC and `tracing::warn!`-ing on invalid → verify: unit tests "default UTC", "custom timezone", "invalid falls back to UTC"
+- [x] 6.2 Update the Component metadata JSON Schema to declare the optional `timezone` field → verify: `arkflow components show processor vrl --format json` includes `timezone`
+
+## 7. Test coverage
+
+- [x] 7.1 Add a `#[cfg(test)]` module with round-trip tests for string, integer, float, boolean, and each timestamp unit → verify: `cargo test -p arkflow-plugin vrl`
+- [x] 7.2 Add tests for empty input (returns None), runtime-error handling, and compile-error configuration rejection → verify: `cargo test -p arkflow-plugin vrl`
+
+## 8. Validation
+
+- [x] 8.1 `cargo test -p arkflow-plugin` green → verify: command exit 0
+- [x] 8.2 `cargo clippy -p arkflow-plugin --lib` introduces no new warnings vs. baseline → verify: command output
+- [x] 8.3 `openspec validate harden-vrl-processor --strict` passes → verify: command exit 0

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,20 +1,34 @@
 schema: spec-driven
 
-# Project context (optional)
-# This is shown to AI when creating artifacts.
-# Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+# Project context — shown to AI when creating artifacts.
+context: |
+  ArkFlow — high-performance Rust stream processing engine (Tokio + Apache Arrow/DataFusion).
+  Rust 1.88+. Cargo workspace with three crates:
+    - arkflow-core: engine abstractions and traits (Engine, Stream, Pipeline, MessageBatch,
+      and traits Input/Output/Processor/Buffer/Codec).
+    - arkflow-plugin: plugin implementations (input/output/processor/buffer/codec).
+    - arkflow: the main binary.
+  Plugin registration: lazy_static + RwLock<HashMap>; each plugin implements a builder trait
+  and registers via register_*_builder(); all plugins initialized through *_init() functions
+  called from crates/arkflow/src/main.rs.
+  Data model: Apache Arrow RecordBatch wrapped in MessageBatch (columnar); standardized
+  metadata columns prefixed with __meta_.
+  Data flow: Input → Buffer → [Processors] → Output, with backpressure at the 1024-message
+  channel threshold and ordered output via sequence numbers.
+  Config: hierarchical YAML; --validate flag validates config. Errors use thiserror + anyhow,
+  propagated as Result<T, Error>. Component traits use async-trait.
+  Build/test: cargo build --release; cargo test --workspace. Protobuf compiler required for CI.
 
-# Per-artifact rules (optional)
-# Add custom rules for specific artifacts.
-# Example:
-#   rules:
-#     proposal:
-#       - Keep proposals under 500 words
-#       - Always include a "Non-goals" section
-#     tasks:
-#       - Break tasks into chunks of max 2 hours
+# Per-artifact rules.
+rules:
+  proposal:
+    - Always include a "Non-goals" section.
+    - In "Why", cite concrete file:line evidence for the current behavior.
+  design:
+    - Prefer surgical changes over rewrites; touch only what the task requires.
+  specs:
+    - Every Requirement MUST have at least one Scenario using WHEN/THEN.
+    - Use SHALL/MUST for normative statements.
+  tasks:
+    - Group by phase (one top-level section per phase).
+    - Each sub-task should be ≤ 2 hours and verifiable (a test, clippy, or a command check).

--- a/openspec/specs/protobuf-codec/spec.md
+++ b/openspec/specs/protobuf-codec/spec.md
@@ -1,0 +1,51 @@
+# protobuf-codec Specification
+
+## Purpose
+TBD - created by archiving change harden-protobuf-codec. Update Purpose after archive.
+## Requirements
+### Requirement: Type-mismatched fields error instead of silently dropping
+When an Arrow column's datatype does not match the proto field's `Kind` during `arrow_to_protobuf`, the processor/codec SHALL return an error naming the field, the expected proto kind, and the actual Arrow datatype. It SHALL NOT silently skip the field.
+
+#### Scenario: Mismatched integer width surfaces an error
+- **WHEN** an Arrow `Int32` column is encoded into a proto `int64` field
+- **THEN** the conversion returns an `Err` naming the field and both types, rather than silently omitting the field
+
+### Requirement: Decoded messages share a stable schema
+`protobuf_to_arrow` SHALL build its schema from the message descriptor's full field set with every field nullable, so every decoded message yields the same schema regardless of which fields are present. Concatenating per-message batches SHALL NOT fail with a schema mismatch.
+
+#### Scenario: Absent field does not break concat
+- **WHEN** message A has field `b` set and message B does not
+- **THEN** both decode to the same schema (field `b` present, nullable), and concatenating the two batches succeeds with a null in B's `b` column
+
+### Requirement: Null Arrow values map to the proto field's absence
+During `arrow_to_protobuf`, a null Arrow value SHALL NOT be explicitly written into the encoded proto message; the field is left absent (which in proto3 reads back as the default value), rather than being read through the validity bitmap and explicitly set.
+
+#### Scenario: Null row does not carry another row's value
+- **WHEN** an Arrow column has a null in row j while another row carries a non-default value
+- **THEN** the encoded proto message for row j decodes to the proto default, never to another row's value
+
+### Requirement: Unsupported field types produce an informative error
+When a proto field uses an unsupported kind (nested message, repeated, map, oneof, proto3 optional), the conversion SHALL return an error that includes the field name and `field.kind()`.
+
+#### Scenario: Nested message field reports its kind
+- **WHEN** a proto field of kind message is encountered during `protobuf_to_arrow`
+- **THEN** the error message names the field and includes its kind
+
+### Requirement: Component metadata schema matches runtime config
+The `arrow_to_protobuf` component metadata JSON Schema SHALL declare `fields_to_include`, and the `protobuf_to_arrow` schema SHALL declare `value_field`. Both schemas retain `additionalProperties: false`, so valid runtime configs pass schema validation.
+
+#### Scenario: fields_to_include passes schema validation
+- **WHEN** the `arrow_to_protobuf` metadata is queried
+- **THEN** `arkflow components show processor arrow_to_protobuf --format json` lists `fields_to_include` in the schema properties
+
+#### Scenario: value_field passes schema validation
+- **WHEN** the `protobuf_to_arrow` metadata is queried
+- **THEN** `arkflow components show processor protobuf_to_arrow --format json` lists `value_field` in the schema properties
+
+### Requirement: Test coverage pins the protobuf round-trip and edge cases
+The protobuf codec/processor SHALL ship tests covering at least: an encode→decode round-trip across all supported scalar types (bool, int32, int64, uint32, uint64, float32, float64, string, bytes, enum), the `fields_to_include` option, the `value_field` option, the unsupported-type error path, and the null-value path.
+
+#### Scenario: Scalar round-trip tests exist
+- **WHEN** `cargo test -p arkflow-plugin protobuf` runs
+- **THEN** encode→decode round-trip tests for every supported scalar type pass
+

--- a/openspec/specs/vrl-processor/spec.md
+++ b/openspec/specs/vrl-processor/spec.md
@@ -1,0 +1,63 @@
+# vrl-processor Specification
+
+## Purpose
+TBD - created by archiving change harden-vrl-processor. Update Purpose after archive.
+## Requirements
+### Requirement: String columns round-trip as strings
+An Arrow `Utf8`/`LargeUtf8` column processed by the VRL processor SHALL be emitted as a string column on output. A `Value::Bytes` result column SHALL be emitted as `Utf8` when every value in the column is valid UTF-8, and as `Binary` only when at least one value is not valid UTF-8.
+
+#### Scenario: String column stays a string column
+- **WHEN** an input `Utf8` column named `name` with values `["alice", "bob"]` is processed by a passthrough VRL statement
+- **THEN** the output column `name` has Arrow datatype `Utf8` (not `Binary`) and the same values
+
+#### Scenario: Genuine binary stays binary
+- **WHEN** a VRL result column contains bytes that are not valid UTF-8
+- **THEN** the output column is emitted as `Binary`
+
+### Requirement: Runtime errors are observable
+When `program.resolve()` returns an error for a batch, the VRL processor SHALL log the error and return `Err`; it SHALL NOT silently drop the batch.
+
+#### Scenario: A fallible statement that fails surfaces an error
+- **WHEN** a batch is processed with a VRL statement `parse_json!(.message)` and `.message` is not valid JSON
+- **THEN** the processor logs the VRL diagnostic and returns `Err`, and the batch is not silently discarded
+
+### Requirement: All Arrow timestamp units are supported
+The VRL processor SHALL accept Arrow `Timestamp` columns of every time unit — `Second`, `Millisecond`, `Microsecond`, and `Nanosecond` — and SHALL NOT drop a column because of its unit.
+
+#### Scenario: Non-nanosecond timestamp column is preserved
+- **WHEN** an input `Timestamp(Second, _)` column is processed
+- **THEN** the column is read using the second-precision array and reaches the VRL program (it is not dropped)
+
+#### Scenario: Unset timestamp becomes null, not epoch
+- **WHEN** a timestamp value cannot be converted to a VRL timestamp
+- **THEN** it is represented as a VRL null rather than being silently coerced to 1970-01-01
+
+### Requirement: Unsupported result shapes fail loudly
+A VRL result that is not a row object (or array of row objects) — including scalars, nested `Object`, `Array`, and `Regex` — SHALL cause the processor to return a clear error naming the unsupported shape. It SHALL NOT produce an empty batch or silently lose data.
+
+#### Scenario: Scalar result returns an error
+- **WHEN** a VRL statement returns a scalar (e.g. `1 + 1`)
+- **THEN** the processor returns an `Err` describing the unsupported scalar result, rather than an empty batch
+
+### Requirement: Timezone is configurable
+The VRL processor SHALL accept an optional `timezone` configuration field. When absent, it SHALL default to the platform local timezone (VRL's `TimeZone::default()`, which is today's behavior). An invalid timezone string SHALL fall back to the default with a warning rather than failing configuration.
+
+#### Scenario: Default timezone is the platform local timezone
+- **WHEN** a VRL processor is configured without a `timezone` field
+- **THEN** it uses the platform local timezone, matching today's behavior
+
+#### Scenario: Custom timezone is honored
+- **WHEN** a VRL processor is configured with `timezone: "Asia/Shanghai"`
+- **THEN** VRL timestamp operations use that timezone
+
+#### Scenario: Invalid timezone falls back to the default
+- **WHEN** a VRL processor is configured with an unparseable `timezone` string
+- **THEN** configuration does not fail; the processor logs a warning and uses the platform local timezone
+
+### Requirement: Test coverage pins the data-correctness contracts
+The VRL processor SHALL ship a unit-test module covering at least: string round-trip, empty input, a failing runtime statement, a compile-error configuration, and each timestamp unit.
+
+#### Scenario: Type round-trip tests exist
+- **WHEN** `cargo test -p arkflow-plugin` runs
+- **THEN** tests for string, numeric, boolean, and each timestamp-unit round-trips pass
+


### PR DESCRIPTION
## Summary

Hardens two processors against silent data loss/corruption, with regression tests and OpenSpec specs. Both were found to silently drop or corrupt user data.

## VRL processor (`processor/vrl.rs`)

Previously the only processor with **zero** tests. Fixes:
- **String round-trip** — `Utf8` columns no longer become `Binary` after VRL (`Value::Bytes` resolved to `Utf8` when the whole column is valid UTF-8)
- **Runtime errors observable** — `program.resolve()` errors are logged and returned as `Err` (routed to `error_output`) instead of silently dropping the batch
- **All timestamp units** — `Second`/`Millisecond`/`Microsecond`/`Nanosecond` all supported (only Nanosecond worked before; others were dropped column-wide)
- **Unsupported result shapes error** — scalar/Object/Array/Regex results return a clear error instead of an empty batch
- Additive `timezone` config option (defaults to platform local)

Adds a `#[cfg(test)]` module: **10 tests**.

## Protobuf codec/processor (`component/protobuf.rs`, `processor/protobuf.rs`, `codec/protobuf.rs`)

Fixes:
- **Type-mismatched columns error** instead of being silently dropped (downcast failure was a silent field skip)
- **Stable descriptor-driven schema** in `protobuf_to_arrow` — `concat_batches` no longer fails at runtime when optional/absent fields differ across messages
- **Null Arrow values map to proto field absence** instead of being coerced to the proto default through the validity bitmap
- **Unsupported-field errors include `field.kind()`**
- **Metadata schema** declares `fields_to_include` / `value_field` so valid configs pass `arkflow schema` / IDE validation
- Documents the supported/unsupported field-type matrix; clears ~10 pre-existing clippy warnings

Adds **17 tests** (codec encode↔decode round-trip, full scalar coverage, `fields_to_include`, type-mismatch error, absent-field concat, null path, nested-field error).

## OpenSpec

- Populated `openspec/config.yaml` with project context + per-artifact rules
- Archived two changes (`harden-vrl-processor`, `harden-protobuf-codec`): proposal → design → specs → tasks
- Main specs added: `openspec/specs/vrl-processor/`, `openspec/specs/protobuf-codec/`

## Verification

- `cargo test --workspace` green (arkflow-core 118, arkflow-plugin 157)
- `cargo clippy -p arkflow-plugin --lib`: no new warnings (protobuf clippy cleared)
- `arkflow schema` emits valid JSON Schema; `components show` lists the new config fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timezone configuration for VRL processing, with safe fallback for invalid values.
  * Improved preservation of UTF-8, binary, timestamp, and null values during VRL and Protobuf conversions.
  * Added support for filtering Protobuf fields during encoding.

* **Bug Fixes**
  * Conversion type mismatches and unsupported Protobuf fields now return clear errors instead of silently dropping data.
  * Protobuf output schemas remain stable when fields are absent.
  * VRL runtime failures and unsupported result shapes are now surfaced as errors.

* **Documentation**
  * Documented supported and unsupported Protobuf field types and conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->