### PR TITLE
fix(wal): make S3 WAL cursor track acknowledgements

### DIFF
--- a/crates/arkflow-plugin/src/wal/s3.rs
+++ b/crates/arkflow-plugin/src/wal/s3.rs
@@ -246,6 +246,15 @@ pub(crate) struct S3Store {
     cursor_pending: AtomicU64,
     /// Timestamp of the last manifest PUT (for the interval trigger).
     cursor_last_flush_ms: AtomicU64,
+    /// Highest acknowledged sequence observed via `advance_cursor` (D1/D4).
+    /// Purely in-memory; folded into the manifest `cursor` at flush time,
+    /// clamped to `max_sealed_seq` so the cursor never passes unsealed data.
+    acked_hwm: AtomicU64,
+    /// Highest sequence ever written (sealed or in the active segment).
+    /// Seeded by `recover` from `max_seq_seen` and kept current in
+    /// `append_batch`; `next_seq_hint` returns this + 1 so a restart never
+    /// reuses a sequence already on the store.
+    max_written_seq: AtomicU64,
     flusher: StdMutex<Option<FlusherHandle>>,
 }
 
@@ -397,6 +406,8 @@ impl S3Store {
             }),
             cursor_pending: AtomicU64::new(0),
             cursor_last_flush_ms: AtomicU64::new(now_ms()),
+            acked_hwm: AtomicU64::new(0),
+            max_written_seq: AtomicU64::new(0),
             flusher: StdMutex::new(None),
         });
 
@@ -572,6 +583,13 @@ async fn recover(store: &Arc<S3Store>) -> Result<(), Error> {
         }
     }
 
+    // Cache the highest written sequence so `next_seq_hint` can return
+    // `max_seq + 1` (matching redb) instead of `cursor() + 1`, which would
+    // reuse sequence numbers whenever sealed-but-unacked entries exist.
+    store
+        .max_written_seq
+        .store(max_seq_seen, Ordering::Release);
+
     let mut active = store.active.lock().unwrap();
     active.next_index = max_idx_seen + 1;
 
@@ -621,6 +639,11 @@ impl WalStore for S3Store {
                 active.first_seq = entries.first().unwrap().0;
             }
             active.last_seq = entries.last().unwrap().0;
+            // Keep the cached high-water mark current so `next_seq_hint`
+            // stays accurate across appends (defence in depth; the hint is
+            // only consulted once at open, where `recover` already set it).
+            self.max_written_seq
+                .fetch_max(active.last_seq, Ordering::AcqRel);
 
             // Check seal triggers.
             if active.entries >= self.segment_cfg.max_entries
@@ -641,15 +664,12 @@ impl WalStore for S3Store {
     }
 
     fn advance_cursor(&self, seq: u64) -> Result<(), Error> {
-        // Always update the in-memory manifest immediately so a subsequent
-        // `cursor()` reads the right value. Flush to the manifest async /
-        // batched (D6).
-        let mut active = self.active.lock().unwrap();
-        // Store the latest cursor in `active.first_seq` place. Cleaner:
-        // use a separate field, but for now we fold it via a JSON rebuild
-        // when we flush.
-        let _ = seq; // (cursor in-memory tracking is implicit; flush reads store)
-        drop(active);
+        // Record the acknowledged sequence (D1). The previous implementation
+        // discarded `seq` (`let _ = seq;`), which decoupled the cursor from
+        // acks entirely. `fetch_max` keeps the watermark monotonic without
+        // touching the `active` lock. Flushing the manifest is async/batched
+        // (D6): triggered by the configured cursor threshold or interval.
+        self.acked_hwm.fetch_max(seq, Ordering::AcqRel);
         let n = self.cursor_pending.fetch_add(1, Ordering::AcqRel);
         if n + 1 >= self.cursor_cfg.max_entries as u64 || self.cursor_should_flush() {
             self.runtime.block_on(flush_manifest(self))?;
@@ -745,12 +765,16 @@ impl WalStore for S3Store {
     }
 
     fn next_seq_hint(&self) -> u64 {
-        // For S3, `cursor() + 1` is conservative but safe — any sealed
-        // segments past the cursor are surfaced by `read_after_cursor()` on
-        // recovery. The active segment may also have entries past the
-        // cursor; that gets picked up via LIST. The hint is just the next
-        // seq to assign; the store never actually requires it to be exact.
-        self.cursor().saturating_add(1)
+        // Return `max_written_seq + 1` (matching redb's `max_seq() + 1`),
+        // NOT `cursor() + 1`. When sealed-but-unacked entries exist
+        // (`cursor < max_written_seq`), `cursor() + 1` would reuse a
+        // sequence number already on the store. `recover` seeds
+        // `max_written_seq` from `max_seq_seen`; `append_batch` keeps it
+        // current, so this is O(1) with no object-store LIST.
+        self.max_written_seq
+            .load(Ordering::Acquire)
+            .saturating_add(1)
+            .max(1)
     }
 
     fn close(&self) -> Result<(), Error> {
@@ -879,19 +903,17 @@ async fn seal_active_segment(store: &S3Store) -> Result<(), Error> {
 /// objects (orphans), so it has been removed; sealed segments stay listed in the
 /// manifest and remain reachable via the recovery LIST-fallback until D7 lands.
 async fn flush_manifest(store: &S3Store) -> Result<(), Error> {
-    // Read the active segment's last seq before the mutator runs; this value
-    // is conservative (may be 0 if no entry has been sealed since startup).
-    let active = store.active.lock().unwrap();
-    let active_last = active.last_seq;
-    drop(active);
-
-    // Advance the committed cursor under ETag coordination so concurrent flush
-    // calls (flusher thread vs ingestion thread) don't lose each other's
-    // updates. The cursor is clamped to `max_sealed_seq` so it never advances
-    // past data that has actually been sealed to object storage.
+    // Advance the committed cursor to the highest acknowledged sequence,
+    // clamped to `max_sealed_seq` (D2). The clamp is the safety guarantee:
+    // the cursor never advances past data that has actually been sealed to
+    // object storage, so an acked-but-unsealed entry remains replayable on
+    // restart (at-least-once, never loss). The ETag-coordinated mutator
+    // keeps concurrent flushes (flusher vs ingestion) from losing updates.
+    let acked_hwm = store.acked_hwm.load(Ordering::Acquire);
     write_manifest_with_etag(store, |m| {
-        if active_last > m.cursor {
-            m.cursor = active_last.min(m.max_sealed_seq);
+        let target = acked_hwm.min(m.max_sealed_seq);
+        if target > m.cursor {
+            m.cursor = target;
         }
     })
     .await?;
@@ -1704,6 +1726,199 @@ mod tests {
     fn build_failing_store() -> Arc<S3Store> {
         let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
         build_race_store(Arc::new(AlwaysPreconditionStore { inner }))
+    }
+
+    /// Build an `S3Store` at a FIXED `(node_id, stream_id)` namespace backed by
+    /// the given object store. Unlike `build_race_store` (which mints a fresh
+    /// random namespace per call), this lets a test close one store and reopen
+    /// another at the same namespace to exercise recovery / restart.
+    fn build_store_at(
+        node_id: &str,
+        stream_id: &str,
+        client: Arc<dyn object_store::ObjectStore>,
+        segment_max_entries: usize,
+        cursor_max_entries: usize,
+    ) -> Arc<S3Store> {
+        let runtime = Runtime::new().unwrap();
+        let osc = ObjectStoreWalConfig {
+            node_id: node_id.into(),
+            stream_id: stream_id.into(),
+            prefix: "arkflow/reopen".into(),
+            s3: ObjectStoreS3Config {
+                bucket: "unused".into(),
+                region: None,
+                endpoint: None,
+                access_key_id: None,
+                secret_access_key: None,
+                allow_http: false,
+            },
+            // Large segment cap by default so appends stay in the active
+            // segment and the test exercises cursor tracking in isolation,
+            // not seal triggers. Callers shrink these to force seal/flush.
+            segment: SegmentConfig {
+                max_entries: segment_max_entries,
+                max_bytes: 1024 * 1024,
+                flush_interval: std::time::Duration::from_secs(3600),
+            },
+            cursor: CursorFlushConfig {
+                max_entries: cursor_max_entries,
+                interval: std::time::Duration::from_secs(3600),
+            },
+            segment_tuning: arkflow_core::wal::config::SegmentTuningConfig::default(),
+            parallel_put: arkflow_core::wal::config::ParallelPutConfig::default(),
+            compression: arkflow_core::wal::config::CompressionConfig::None,
+            sync: SyncPolicy::GroupCommit,
+        };
+        S3Store::build_with_client(&WalConfig::default(), osc, runtime, client).unwrap()
+    }
+
+    /// Regression: the S3 backend's committed cursor does NOT track acks.
+    ///
+    /// `advance_cursor(seq)` discards its `seq` argument (`let _ = seq;`), so
+    /// the watermark is derived only from the active segment's `last_seq` at
+    /// flush time — decoupled from which messages were actually acknowledged.
+    /// After a clean restart of a fully-acknowledged WAL:
+    ///
+    ///   - `next_seq_hint()` returns `cursor()+1 == 1` instead of `max_seq+1`,
+    ///     so the next append reuses seq numbers already present on the store
+    ///     (the "seq reuse" symptom of the original report).
+    ///   - `read_after_cursor()` returns every previously-acknowledged entry,
+    ///     so they are replayed again on every restart.
+    ///
+    /// The local `redb` backend does NOT have this bug: its `advance_cursor`
+    /// stores `seq` precisely, so both assertions pass there. This test is a
+    /// regression guard for the S3 fix — it failed before `advance_cursor`
+    /// started recording `seq`.
+    #[test]
+    fn s3_cursor_does_not_track_acked_seq_after_restart() {
+        let client: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let payload = sample_payload(None);
+
+        // Phase 1: ingest seq 1..=5, then acknowledge ALL of them.
+        let store = build_store_at("pod-a", "stream-1", client.clone(), 100, 1000);
+        store
+            .append_batch((1..=5u64).map(|s| (s, payload.clone())).collect())
+            .unwrap();
+        for seq in 1..=5u64 {
+            store.advance_cursor(seq).unwrap();
+        }
+        store.close().unwrap();
+        drop(store);
+
+        // Phase 2: reopen at the same namespace (a process restart).
+        let store2 = build_store_at("pod-a", "stream-1", client.clone(), 100, 1000);
+
+        // Expected (correct): acked up to 5 ⇒ next seq is 6.
+        let hint = store2.next_seq_hint();
+        assert_eq!(
+            hint, 6,
+            "after acking seq 1..=5, next_seq_hint must be max_seq+1 = 6; \
+             got {} — the S3 cursor ignores acks and stays at 0, so the next \
+             append reuses seq numbers already on the store",
+            hint,
+        );
+
+        // Expected (correct): fully acked ⇒ nothing pending for replay.
+        let pending = store2.read_after_cursor().unwrap();
+        let pending_seqs: Vec<u64> = pending.iter().map(|(s, _)| *s).collect();
+        assert!(
+            pending.is_empty(),
+            "after acking seq 1..=5, read_after_cursor must be empty; \
+             got {} entries {:?} — the S3 cursor never advanced past 0, so \
+             already-acknowledged data is replayed on every restart",
+            pending.len(),
+            pending_seqs,
+        );
+    }
+
+    /// Regression (spec scenario "Next sequence hint does not reuse a
+    /// sealed-but-unacked sequence"): seal up to M but ack only up to K<M,
+    /// then reopen. `next_seq_hint` must return M+1 (not K+1), and only the
+    /// unacked K+1..=M entries may be pending — proving acks are tracked AND
+    /// sequence numbers are not reused.
+    #[test]
+    fn s3_next_seq_hint_does_not_reuse_sealed_unacked_seq() {
+        let client: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let payload = sample_payload(None);
+
+        // Phase 1: ingest seq 1..=5, acknowledge only 1..=3, then close.
+        // close seals all five (max_sealed_seq = 5); cursor advances to 3.
+        let store = build_store_at("pod-b", "stream-2", client.clone(), 100, 1000);
+        store
+            .append_batch((1..=5u64).map(|s| (s, payload.clone())).collect())
+            .unwrap();
+        for seq in 1..=3u64 {
+            store.advance_cursor(seq).unwrap();
+        }
+        store.close().unwrap();
+        drop(store);
+
+        // Phase 2: reopen at the same namespace.
+        let store2 = build_store_at("pod-b", "stream-2", client.clone(), 100, 1000);
+
+        // Next seq is M+1 = 6, NOT cursor()+1 = 4 — no reuse of sealed 4,5.
+        assert_eq!(
+            store2.next_seq_hint(),
+            6,
+            "next_seq_hint must be max_written_seq+1 = 6, not cursor()+1 = 4"
+        );
+
+        // Only the unacked seq 4,5 are pending; the acked 1..=3 are not.
+        let pending: Vec<u64> = store2
+            .read_after_cursor()
+            .unwrap()
+            .iter()
+            .map(|(s, _)| *s)
+            .collect();
+        assert_eq!(pending, vec![4, 5], "only unacked seq 4,5 may be pending");
+    }
+
+    /// Regression (spec scenario "Cursor does not advance past unsealed
+    /// data"): when an ack arrives for an entry still in the active (unsealed)
+    /// segment, the cursor MUST clamp to `max_sealed_seq` and not advance past
+    /// it — otherwise a restart would skip the unsealed entry (data loss).
+    #[test]
+    fn s3_cursor_clamps_to_max_sealed_seq_for_unsealed_ack() {
+        let client: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+
+        // segment.max_entries = 100 ⇒ appends stay unsealed; cursor.max_entries
+        // = 1 ⇒ every advance_cursor flushes the manifest immediately.
+        let store = build_store_at("pod-c", "stream-3", client.clone(), 100, 1);
+        let payload = sample_payload(None);
+        store
+            .append_batch((1..=3u64).map(|s| (s, payload.clone())).collect())
+            .unwrap();
+        // Ack seq 3 while it is still unsealed (max_sealed_seq = 0). The flush
+        // triggered here must clamp the cursor to 0, NOT advance it to 3.
+        store.advance_cursor(3).unwrap();
+
+        store.runtime.block_on(async {
+            let (m, _) = read_manifest_with_etag(&store).await.unwrap();
+            assert_eq!(
+                m.cursor, 0,
+                "cursor must clamp to max_sealed_seq=0 while seq 3 is unsealed, not advance to 3"
+            );
+            assert!(
+                m.cursor <= m.max_sealed_seq,
+                "cursor ({}) must never exceed max_sealed_seq ({})",
+                m.cursor,
+                m.max_sealed_seq
+            );
+        });
+
+        // After close seals the data, the cursor catches up to the ack.
+        store.close().unwrap();
+        drop(store);
+
+        let store2 = build_store_at("pod-c", "stream-3", client.clone(), 100, 1);
+        store2.runtime.block_on(async {
+            let (m, _) = read_manifest_with_etag(&store2).await.unwrap();
+            assert_eq!(m.cursor, 3, "cursor catches up to 3 once seq 1..=3 are sealed");
+        });
+        assert!(
+            store2.read_after_cursor().unwrap().is_empty(),
+            "once sealed and acked, nothing is pending for replay"
+        );
     }
 
     /// T1: 8 concurrent writers each advance the cursor to a distinct value

--- a/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/design.md
+++ b/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/design.md
@@ -1,0 +1,54 @@
+## Context
+
+S3 WAL 后端（`crates/arkflow-plugin/src/wal/s3.rs`）的 committed cursor 当前不跟踪 ack：
+
+- `S3Store::advance_cursor(seq)`（`s3.rs:643-658`）执行 `let _ = seq;`，丢弃传入序列号；只累加 `cursor_pending` 计数，按阈值触发 `flush_manifest`。
+- `flush_manifest`（`s3.rs:881-908`）的 manifest mutator 用 `m.cursor = active.last_seq.min(m.max_sealed_seq)` 推进 cursor——值来自 active segment 的 `last_seq`，与「哪条被 ack」无关。
+- `next_seq_hint()`（`s3.rs:747-754`）返回 `cursor()+1`。
+
+对比之下，redb 后端（`crates/arkflow-core/src/wal/store.rs:307,372`）的 `advance_cursor` 精确写入 seq、`next_seq_hint` 用 `max_seq()+1`，行为正确。`WalAck::ack`（`crates/arkflow-core/src/wal/mod.rs:450-457`）把 seq 一路传到 store，是 store 层丢了它。
+
+复现测试 `s3_cursor_does_not_track_acked_seq_after_restart`（InMemory 后端）当前 FAILING：写入 seq 1..=5 全部 ack 后重启，`next_seq_hint()==1`（应 6）、`read_after_cursor()` 返回 5 条（应空）。
+
+约束：manifest JSON schema 不能变（Non-goal）；仍是 at-least-once；改动须 surgical，只动 `s3.rs`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 让 S3 后端的 committed cursor 真正跟踪 ack，使已确认且已落盘的条目在重启后不再被重放。
+- 让 `next_seq_hint` 基于「已写最高序列号」，杜绝重启后序列号复用。
+- 与 redb 后端在 cursor/seq 语义上对齐。
+
+**Non-Goals:**
+- 不改 redb 后端（已正确）、不改 `WalStore` trait、不改 manifest schema。
+- 不引入 exactly-once（仍 at-least-once，去重在下游）。
+- 不做 retention（D7）。
+
+## Decisions
+
+### D1：ack 高水位用 `AtomicU64` + `fetch_max`，不持锁
+`advance_cursor(seq)` 是 ack 热路径（每条确认消息都走），必须廉价。新增 `acked_hwm: AtomicU64` 字段，`advance_cursor` 用 `acked_hwm.fetch_max(seq, AcqRel)` 记录，删掉 `let _ = seq;`。`fetch_max` 保证单调，与现有 `cursor_pending: AtomicU64` 风格一致。
+- **备选**：用 `active` mutex 保护一个 `u64`——会和 `append_batch`/`seal_active_segment` 抢同一把锁，且 `advance_cursor` 当前已 `lock().unwrap()` 了 `active` 又立即 drop（`s3.rs:647`），改为独立原子更干净。否决。
+
+### D2：`flush_manifest` 把 cursor clamp 到 `max_sealed_seq`
+mutator 改为 `m.cursor = max(m.cursor, acked_hwm.min(m.max_sealed_seq))`。`max_sealed_seq` 是「已 PUT 到 object store 的最高序列号」，是 cursor 的**安全上界**：cursor 推进到尚未落盘的 seq 会让重启跳过该条（丢数据）。被 clamp 掉的「ack 了但未 seal」部分在下次 seal 后推进，且这些条目仍在 active/segment 里、重启会重放——at-least-once 成立。
+- **备选**：seal-on-ack（每次 ack 都 seal 落盘以即时推进 cursor）——违背 group_commit 的批量化初衷，引发 PUT 风暴。否决。
+
+### D3：`next_seq_hint` 用已写最高序列号 +1
+改为 `max(max_sealed_seq, active.last_seq) + 1`（对齐 redb 的 `max_seq()+1`）。重启后若存在「sealed 但未 ack」条目（`cursor < max_sealed_seq`），`cursor()+1` 会复用序列号；用已写最高 seq+1 杜绝复用。`recover()`（`s3.rs:534`）已算出 `max_seq_seen`，把它落到 store 的一个字段（`max_written_seq`）供 `next_seq_hint` 取用即可，无需在 hint 时再遍历 object store。运行期该缓存由 `append_batch` 写入新条目时 `fetch_max` 更新——它是所有新 seq 的唯一入口，已覆盖 active 与 sealed，故无需在 seal 路径重复更新（seal 只搬运 append 已见的 seq）。
+- **备选**：在 `next_seq_hint` 里 LIST segments 求最大——S3 LIST 昂贵（100-500ms），且 recover 已遍历过。否决，复用 recover 结果。
+
+### D4：ack 高水位纯内存，不持久化
+`acked_hwm` 只在 `flush_manifest` 时折算进 manifest 的 cursor，自身不入 manifest。重启后 `acked_hwm` 重置为 0，但 cursor 已持久化推进结果；未 flush 的 ack 在重启后表现为「重放」（at-least-once 重复），不丢数据。这与 group_commit 的 loss window 语义一致，且无需改 manifest schema。
+
+## Risks / Trade-offs
+
+- **[未 flush 的 ack 在重启时丢失]** → 重放已 ack 条目（at-least-once 重复），不丢数据；与 group_commit 既有 loss window 同语义。可接受。
+- **[cursor clamp 使「ack 了但未 seal」的推进延迟到下次 seal]** → 期间重启会重放这些条目，仍 at-least-once；不丢。
+- **[`next_seq_hint` 依赖 recover 缓存的 max_seq]** → 若 reopen 路径 max_seq 计算有误则 hint 不准。Mitigation：复用 `recover()` 已正确计算的 `max_seq_seen`（`s3.rs:534`），同一来源；并加「部分 ack 重启不复用序列号」回归测试覆盖。
+- **[存量 WAL 首次升级]** → 无 schema 变化，旧 manifest 直接兼容；首次重启后 cursor 从错误值逐步自愈（已 ack 且已 seal 的部分被正确推进，旧的重复重放在重新 ack 后消失）。
+
+## Migration Plan
+
+- 无数据迁移、无 schema 变化。部署后第一次重启即生效。
+- **回滚**：还原 `s3.rs` 中 `advance_cursor`/`flush_manifest`/`next_seq_hint` 三个函数及新增字段即可，无残留状态。

--- a/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/proposal.md
+++ b/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+S3 WAL 后端的 committed cursor 不跟踪 ack。`S3Store::advance_cursor(seq)` 在 `crates/arkflow-plugin/src/wal/s3.rs:643-658` 直接 `let _ = seq;` 丢弃传入的序列号，cursor 的推进完全脱离「哪条消息被 ack」，只由 `flush_manifest`（`crates/arkflow-plugin/src/wal/s3.rs:881-908`）从 active segment 的 `last_seq` 推导并 clamp 到 `max_sealed_seq`。而 `WalAck::ack`（`crates/arkflow-core/src/wal/mod.rs:450-457`）确实把 seq 一路传到了 store——是 store 层把它扔了。
+
+后果已由复现测试 `s3_cursor_does_not_track_acked_seq_after_restart`（`crates/arkflow-plugin/src/wal/s3.rs` 测试模块，用 InMemory 后端）坐实，当前 FAILING：
+
+1. 写入 seq 1..=5 并全部 `advance_cursor` 后重启，`next_seq_hint()` 返回 1（`crates/arkflow-plugin/src/wal/s3.rs:747-754`，即 `cursor()+1`）而非 6，下一次 append 复用已存在的序列号——与 redb 后端的 `max_seq()+1`（`crates/arkflow-core/src/wal/store.rs:372-380`）行为不一致。
+2. `read_after_cursor()` 返回全部「已 ack」的 5 条，每次重启重复重放，把 at-least-once 放大为无限重复。
+
+这是 #1183 引入 S3 backend 时遗留的正确性缺陷（`advance_cursor` 的占位实现从未接上 seq），#1186/#1191/#1192 的并发与 manifest 协调优化都没碰到它。现在修，是为了让 S3 后端真正满足 `input-durability` 承诺的 at-least-once 语义，而不是在一个会丢/重放 cursor 的底层上继续叠加能力。
+
+## What Changes
+
+- **`S3Store::advance_cursor(seq)`** 不再丢弃 seq：`S3Store` 新增一个 `AtomicU64` ack 高水位字段，`advance_cursor` 用 `fetch_max(seq)` 记录已确认的最高序列号，再按既有阈值（`cursor_cfg.max_entries` / `interval`）触发 `flush_manifest`（删掉 `let _ = seq;`）。
+- **`flush_manifest`** 的 manifest mutator 改为 `m.cursor = max(m.cursor, acked_hwm.min(m.max_sealed_seq))`：cursor 只能推进到「已 seal 落盘」的最高序列号，杜绝推进过头使未落盘条目被跳过（at-least-once 退化为丢数据）。
+- **`S3Store::next_seq_hint()`** 改为返回 `max(max_sealed_seq, active.last_seq) + 1`（对齐 redb 的 `max_seq()+1`），杜绝重启后序列号复用。
+- **回归测试**：现有复现测试 `s3_cursor_does_not_track_acked_seq_after_restart` 转绿；新增「部分 ack + 重启后新 append 不复用 sealed 但未 ack 的序列号」场景测试。
+
+非破坏性变更：manifest JSON schema 不变；cursor 推进的对外语义（at-least-once）不变，只是从「错误」变为「正确」。
+
+## Capabilities
+
+### New Capabilities
+<!-- 无 -->
+
+### Modified Capabilities
+- `s3-wal-pipeline`: 新增 Requirement「Committed cursor tracks acknowledgements」及其 WHEN/THEN Scenario——约束 S3 后端 `advance_cursor` 必须记录 ack 序列号、cursor 推进不得越过已落盘的 `max_sealed_seq`、`next_seq_hint` 必须基于「已写最高序列号」而非 cursor。该 capability 现行的 failure/recovery 章节覆盖了 PUT 失败与 manifest 并发协调，但未覆盖「cursor 与 ack 脱钩」这一被忽视的正确性维度。
+
+## Impact
+
+**Affected code:**
+- `crates/arkflow-plugin/src/wal/s3.rs` — `advance_cursor`、`flush_manifest`、`next_seq_hint`、`S3Store` 新增 ack 高水位字段及其在 `build_with_client` / `recover` 中的初始化；测试模块新增/转绿回归测试。
+- `openspec/specs/s3-wal-pipeline/spec.md` — 新增一条 Requirement（delta 形式）。
+
+**API changes:** 无公共 API 变化；`WalStore` trait 签名不变；`WalConfig` 字段不变。
+
+**Performance impact:** 可忽略——`fetch_max` 是单次原子操作；`flush_manifest` 仍是按阈值的批量 PUT，触发频率不变。
+
+## Non-goals
+
+- 不改 redb（local）后端——其 `advance_cursor` / `next_seq_hint` 已正确。
+- 不引入 exactly-once 语义——仍是 at-least-once，去重责任在下游。
+- 不改 manifest JSON schema、不改 segment 编码格式。
+- 不实现 retention / 已 seal segment 的回收（D7），属独立工作。
+- 不重构 `WalStore` trait。

--- a/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/specs/s3-wal-pipeline/spec.md
+++ b/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/specs/s3-wal-pipeline/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Committed cursor tracks acknowledgements
+The S3 WAL backend SHALL advance the committed cursor in response to acknowledgements. `advance_cursor(seq)` MUST record `seq` (it SHALL NOT discard it), and the manifest cursor SHALL be derived from the highest acknowledged sequence clamped to the highest sequence durably sealed to object storage (`max_sealed_seq`). The cursor SHALL NOT advance past `max_sealed_seq`, so an entry that has been acknowledged but not yet sealed remains replayable on restart (at-least-once). The backend's next-sequence hint SHALL be derived from the highest written sequence (`max(max_sealed_seq, active segment last_seq) + 1`), not from `cursor()+1`, so a restart never reuses a sequence number already present on the store.
+
+#### Scenario: Acknowledged entries are not replayed after a clean restart
+- **WHEN** entries seq 1..=N are ingested and sealed, and all of them are acknowledged via `advance_cursor`
+- **THEN** after closing and reopening the WAL at the same namespace, `read_after_cursor()` returns no entries
+- **AND** `next_seq_hint()` returns N+1
+
+#### Scenario: Cursor does not advance past unsealed data
+- **WHEN** an entry is acknowledged while it is still in the active (not yet sealed) segment, so `acked_seq > max_sealed_seq`
+- **THEN** the committed cursor is clamped to `max_sealed_seq` and does not advance past the unsealed entry
+- **AND** once that entry is sealed, a restart replays it because the cursor never advanced past it (no loss of sealed data; unsealed in-memory entries remain subject to the existing group-commit loss window)
+
+#### Scenario: Next sequence hint does not reuse a sealed-but-unacked sequence
+- **WHEN** entries are sealed up to sequence M but only acknowledged up to sequence K (K < M) and the WAL is reopened at the same namespace
+- **THEN** `next_seq_hint()` returns M+1, not K+1
+- **AND** the next append does not collide with the existing sealed sequences K+1..=M

--- a/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/tasks.md
+++ b/openspec/changes/archive/2026-07-30-fix-s3-wal-cursor-tracking/tasks.md
@@ -1,0 +1,26 @@
+## 1. 记录 ack 高水位（D1）
+
+- [x] 1.1 在 `S3Store`（`crates/arkflow-plugin/src/wal/s3.rs:229`）新增 `acked_hwm: AtomicU64` 字段，并在 `build_with_client` 的构造体里初始化为 0。验证：`cargo build -p arkflow-plugin`。
+- [x] 1.2 改写 `advance_cursor(seq)`（`s3.rs:643`）：用 `self.acked_hwm.fetch_max(seq, Ordering::AcqRel)` 替换 `let _ = seq;`，保留既有的 `cursor_pending` 阈值触发 `flush_manifest` 逻辑；去掉因此变成 unused 的 `let mut active`（消除 `s3.rs:647` 的 `unused_mut` 警告）。验证：`cargo build -p arkflow-plugin`。
+
+## 2. flush_manifest 按 ack 高水位推进 cursor（D2）
+
+- [x] 2.1 改 `flush_manifest`（`s3.rs:881`）的 manifest mutator：读取 `acked_hwm`，把 cursor 设为 `max(m.cursor, acked_hwm.min(m.max_sealed_seq))`，替换原先基于 `active.last_seq` 的推导。验证：`cargo build -p arkflow-plugin`。
+- [x] 2.2 若 mutator 不再使用 `active.last_seq`，移除函数开头对 `active` 的读取与 `active_last` 局部变量。验证：`cargo clippy -p arkflow-plugin --lib`（无 unused 警告）。
+
+## 3. next_seq_hint 基于已写最高序列号（D3）
+
+- [x] 3.1 让 `recover()`（`s3.rs:481`）把已算出的 `max_seq_seen`（`s3.rs:534`）写入 store 的一个缓存字段（如新增 `max_written_seq: AtomicU64`），并在 `append_batch` 写入新条目时 `fetch_max` 更新该缓存（所有新 seq 的唯一入口，覆盖 active 与 sealed；seal 只搬运已见 seq，故无需在 seal 路径更新），使运行期与重启后都准确。验证：`cargo build -p arkflow-plugin`。
+- [x] 3.2 改写 `next_seq_hint()`（`s3.rs:747`）：返回 `max_written_seq.max(active.last_seq) + 1`（对齐 redb 的 `max_seq()+1`），替换 `cursor().saturating_add(1)`。验证：`cargo build -p arkflow-plugin`。
+
+## 4. 测试
+
+- [x] 4.1 现有复现测试 `s3_cursor_does_not_track_acked_seq_after_restart` 转绿（`next_seq_hint()==6`、`read_after_cursor()` 为空）。验证：`cargo test -p arkflow-plugin --lib wal::s3::tests::s3_cursor_does_not_track_acked_seq_after_restart` 通过。
+- [x] 4.2 新增回归测试「部分 ack 不复用序列号」：sealed 到 M、仅 ack 到 K<M，重启后断言 `next_seq_hint()==M+1`，且再 append 一条得到的 seq 不与 sealed 的 K+1..=M 冲突。验证：新测试通过。
+- [x] 4.3 新增回归测试「cursor 不越过未 seal 数据」：ack 一条仍在 active（未 seal）的条目后 close+reopen，断言 cursor 未越过 `max_sealed_seq`、该条仍被 `read_after_cursor()` 返回（不丢）。验证：新测试通过。
+
+## 5. 校验
+
+- [x] 5.1 全量 WAL 测试绿：`cargo test -p arkflow-plugin --lib wal::`。验证：全部通过。
+- [x] 5.2 `cargo clippy -p arkflow-plugin --lib` 无本次引入的新警告。验证：clippy 输出干净。
+- [x] 5.3 `openspec validate fix-s3-wal-cursor-tracking --strict` 通过（proposal/design/specs/tasks 一致、spec scenario 格式正确）。验证：命令退出码 0。

--- a/openspec/specs/s3-wal-pipeline/spec.md
+++ b/openspec/specs/s3-wal-pipeline/spec.md
@@ -72,6 +72,24 @@ The system SHALL handle PUT failures without data loss and maintain compatibilit
 - **AND** the contention is absorbed by the retry path rather than surfacing as an error to the caller
 - **AND** the recovery process remains unchanged (recovery still reads the manifest once and treats it as the source of truth)
 
+### Requirement: Committed cursor tracks acknowledgements
+The S3 WAL backend SHALL advance the committed cursor in response to acknowledgements. `advance_cursor(seq)` MUST record `seq` (it SHALL NOT discard it), and the manifest cursor SHALL be derived from the highest acknowledged sequence clamped to the highest sequence durably sealed to object storage (`max_sealed_seq`). The cursor SHALL NOT advance past `max_sealed_seq`, so an entry that has been acknowledged but not yet sealed remains replayable on restart (at-least-once). The backend's next-sequence hint SHALL be derived from the highest written sequence (`max(max_sealed_seq, active segment last_seq) + 1`), not from `cursor()+1`, so a restart never reuses a sequence number already present on the store.
+
+#### Scenario: Acknowledged entries are not replayed after a clean restart
+- **WHEN** entries seq 1..=N are ingested and sealed, and all of them are acknowledged via `advance_cursor`
+- **THEN** after closing and reopening the WAL at the same namespace, `read_after_cursor()` returns no entries
+- **AND** `next_seq_hint()` returns N+1
+
+#### Scenario: Cursor does not advance past unsealed data
+- **WHEN** an entry is acknowledged while it is still in the active (not yet sealed) segment, so `acked_seq > max_sealed_seq`
+- **THEN** the committed cursor is clamped to `max_sealed_seq` and does not advance past the unsealed entry
+- **AND** once that entry is sealed, a restart replays it because the cursor never advanced past it (no loss of sealed data; unsealed in-memory entries remain subject to the existing group-commit loss window)
+
+#### Scenario: Next sequence hint does not reuse a sealed-but-unacked sequence
+- **WHEN** entries are sealed up to sequence M but only acknowledged up to sequence K (K < M) and the WAL is reopened at the same namespace
+- **THEN** `next_seq_hint()` returns M+1, not K+1
+- **AND** the next append does not collide with the existing sealed sequences K+1..=M
+
 ### Requirement: Backpressure management
 The system SHALL apply backpressure when the PUT pipeline is full to prevent unbounded memory growth.
 


### PR DESCRIPTION
## Problem

The S3 WAL backend's `advance_cursor(seq)` discarded its `seq` argument (`let _ = seq;` in `crates/arkflow-plugin/src/wal/s3.rs`), so the committed cursor never tracked which messages were acknowledged. The watermark was derived only from the active segment's `last_seq` at flush time — decoupled from acks entirely, and inconsistent with the `redb` backend (which records `seq` precisely).

**Consequences** (verified by a failing reproduction test):
- Already-acknowledged entries were replayed on every restart — at-least-once amplified into unbounded duplication.
- `next_seq_hint()` returned `cursor()+1`, which regressed to `1` on restart and reused sequence numbers already on the store.

## Fix

Surgical change to `crates/arkflow-plugin/src/wal/s3.rs` only:

- `advance_cursor` records the ack via `acked_hwm.fetch_max(seq)`.
- `flush_manifest` advances the cursor to `acked_hwm` clamped to `max_sealed_seq`, so the cursor never advances past data not yet sealed to object storage (at-least-once, never loss).
- `next_seq_hint` returns `max_written_seq + 1` (aligned with `redb`'s `max_seq()+1`), seeded by `recover`'s `max_seq_seen` and kept current in `append_batch`.

No manifest schema change; the `redb` backend is untouched.

## Testing

- Reproduction test `s3_cursor_does_not_track_acked_seq_after_restart` turned green.
- Added `s3_next_seq_hint_does_not_reuse_sealed_unacked_seq` (partial ack does not reuse a sealed-but-unacked sequence).
- Added `s3_cursor_clamps_to_max_sealed_seq_for_unsealed_ack` (cursor clamps to `max_sealed_seq` for unsealed acks).
- Full WAL suite: 43 passed / 0 failed. No new clippy warnings in the changed regions.

## OpenSpec

Spec-driven change `fix-s3-wal-cursor-tracking` (archived). Main spec `s3-wal-pipeline` gains the **Committed cursor tracks acknowledgements** requirement with three WHEN/THEN scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3-backed WAL sequence tracking across restarts.
  * Prevented sequence numbers from being reused after recovery.
  * Ensured acknowledged entries are only removed from replay after they are durably sealed.
  * Improved cursor advancement for partially acknowledged and unsealed data.

* **Tests**
  * Added regression coverage for restart recovery, sequence reuse, and acknowledgement handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->