### PR TITLE
feat: reliability roadmap — CDC, Schema Registry, end-to-end exactly-once (Change 1-3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 examples/output.txt
 
 .run
+# local git worktrees
+.claude/worktrees/
+.dev/worktree/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,7 @@ When creating new plugins, the registration pattern is consistent across all com
    - Key-based partitioning
    - Compression options
    - Acknowledgment levels
+   - Exactly-once transactional production (L2): opt-in via `exactly_once: true` + `transactional_id`; one ack range = one Kafka transaction (see `examples/eos-kafka.yaml`)
 
 5. **MQTT** - MQTT publisher
    - QoS levels

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ This is a Cargo workspace with three crates:
   - Output plugins: Drop, HTTP, InfluxDB, Kafka, MQTT, NATS, Pulsar, Redis, SQL, Stdout
   - Processor plugins: Batch, JSON, Protobuf, Python UDF, SQL, VRL
   - Buffer plugins: Memory, Session Window, Sliding Window, Tumbling Window, Join
-  - Codec plugins: JSON, Protobuf
+  - Codec plugins: JSON, Protobuf, Debezium, Schema Registry
 
 - **`arkflow`** (`crates/arkflow/`) - Main binary executable
 
@@ -439,6 +439,16 @@ When creating new plugins, the registration pattern is consistent across all com
    - Binary format support
    - Schema files (.proto)
    - Descriptor sets
+
+3. **Debezium (JSON)** - Debezium CDC Envelope decoding
+   - Decodes change events (op/before/after/source/ts_ms) into columnar Arrow
+   - Attach to a Kafka input; CDC offset is the Kafka input's ack-gated offset
+   - Covers MySQL/PostgreSQL/MongoDB/SQLServer via Debezium
+
+4. **Schema Registry** - Confluent wire-format Protobuf decoding
+   - Decodes messages by resolving schema id from a Schema Registry (REST)
+   - Per-id descriptor cache; supports multi-version schema evolution
+   - Attach to a Kafka input consuming Confluent-serialized Protobuf
 
 ## Advanced Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -311,6 +311,7 @@ dependencies = [
  "tracing",
  "url",
  "vrl",
+ "wiremock",
  "zstd",
 ]
 
@@ -623,6 +624,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2085,7 +2096,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3476,6 +3487,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,7 +3793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4718,7 +4747,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5849,7 +5878,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6270,7 +6299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7191,7 +7220,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -7230,9 +7259,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7894,7 +7923,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7975,7 +8004,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8648,7 +8677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8899,7 +8928,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9116,7 +9145,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9125,7 +9154,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10296,7 +10325,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10670,6 +10699,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,10 +296,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "spiceai_duckdb_fork",
  "sqlx",
  "subtle",
  "tempfile",
+ "testcontainers",
  "tokio",
  "tokio-modbus",
  "tokio-stream",
@@ -634,6 +636,22 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "rustix 1.1.4",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -1659,6 +1677,80 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.13.1",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-native-certs 0.8.4",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.19",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
 ]
 
 [[package]]
@@ -3610,6 +3702,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "domain"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +3911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,6 +3980,17 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.2",
+ "web-time",
+]
 
 [[package]]
 name = "ff"
@@ -4701,6 +4825,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,6 +4891,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -6420,6 +6573,31 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8397,6 +8575,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8887,7 +9090,7 @@ dependencies = [
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -8968,6 +9171,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "strum"
@@ -9171,6 +9397,37 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.11.0",
+ "ferroid",
+ "futures",
+ "http 1.4.2",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
 
 [[package]]
 name = "thiserror"
@@ -9869,6 +10126,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.2",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9898,6 +10182,12 @@ name = "utf8-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/arkflow-core/src/codec/mod.rs
+++ b/crates/arkflow-core/src/codec/mod.rs
@@ -11,6 +11,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+use async_trait::async_trait;
 use crate::{Bytes, Error, MessageBatch, Resource};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -20,12 +21,14 @@ lazy_static::lazy_static! {
     static ref CODEC_BUILDERS: RwLock<HashMap<String, Arc<dyn CodecBuilder>>> = RwLock::new(HashMap::new());
 }
 
+#[async_trait]
 pub trait Encoder: Send + Sync {
-    fn encode(&self, b: MessageBatch) -> Result<Vec<Bytes>, Error>;
+    async fn encode(&self, b: MessageBatch) -> Result<Vec<Bytes>, Error>;
 }
 
+#[async_trait]
 pub trait Decoder: Send + Sync {
-    fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error>;
+    async fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error>;
 }
 
 pub trait Codec: Encoder + Decoder {}

--- a/crates/arkflow-core/src/output/mod.rs
+++ b/crates/arkflow-core/src/output/mod.rs
@@ -37,6 +37,27 @@ pub trait Output: Send + Sync {
 
     /// Close the output destination connection
     async fn close(&self) -> Result<(), Error>;
+
+    /// Write a batch of messages that share one acknowledgement.
+    ///
+    /// One `write_batch` call corresponds to one ack range and therefore one
+    /// transaction unit. The default implementation writes each message via
+    /// [`write`](Self::write) in order and returns `Err` if any write failed
+    /// (continue-on-error, retaining the last error), preserving the
+    /// historical per-message behavior. Outputs that need exactly-once
+    /// semantics override this to commit the whole batch atomically.
+    async fn write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error> {
+        let mut err = None;
+        for msg in msgs {
+            if let Err(e) = self.write(msg.clone()).await {
+                err = Some(e);
+            }
+        }
+        match err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
 }
 
 /// Output configuration

--- a/crates/arkflow-core/src/stream/mod.rs
+++ b/crates/arkflow-core/src/stream/mod.rs
@@ -451,7 +451,7 @@ impl Stream {
                     }
                     error!("{e}");
                 }
-                Some(err_output) => match err_output.write(msg).await {
+                Some(err_output) => match err_output.write_batch(&[msg]).await {
                     Ok(_) => {
                         if let Err(err) = ack.ack().await {
                             error!("Failed to ack errored message: {}", err);
@@ -463,22 +463,14 @@ impl Stream {
                 },
             },
             ProcessorData::Ok(msgs) => {
-                let size = msgs.len();
-                let mut success_cnt = 0;
-                for msg in msgs {
-                    match output.write(msg).await {
-                        Ok(_) => {
-                            success_cnt += 1;
-                        }
-                        Err(e) => {
-                            error!("{}", e);
+                match output.write_batch(&msgs).await {
+                    Ok(_) => {
+                        if let Err(e) = ack.ack().await {
+                            error!("Failed to ack message: {}", e);
                         }
                     }
-                }
-
-                if success_cnt >= size {
-                    if let Err(e) = ack.ack().await {
-                        error!("Failed to ack message: {}", e);
+                    Err(e) => {
+                        error!("{}", e);
                     }
                 }
             }
@@ -603,6 +595,125 @@ mod tests {
         async fn close(&self) -> Result<(), Error> {
             Ok(())
         }
+    }
+
+    /// Output that counts `write_batch` / `write` calls. `write_batch` is
+    /// overridden (it does not delegate to `write`) so tests can assert that
+    /// the output worker routes a whole ack range through exactly one
+    /// `write_batch` call rather than looping `write`.
+    struct CountingOutput {
+        batch_calls: std::sync::atomic::AtomicU32,
+        batch_len: std::sync::atomic::AtomicU32,
+        write_calls: std::sync::atomic::AtomicU32,
+        fail_batch: std::sync::atomic::AtomicBool,
+    }
+
+    impl CountingOutput {
+        fn new() -> Self {
+            Self {
+                batch_calls: std::sync::atomic::AtomicU32::new(0),
+                batch_len: std::sync::atomic::AtomicU32::new(0),
+                write_calls: std::sync::atomic::AtomicU32::new(0),
+                fail_batch: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+        fn failing() -> Self {
+            let o = Self::new();
+            o.fail_batch
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            o
+        }
+    }
+
+    #[async_trait]
+    impl Output for CountingOutput {
+        async fn connect(&self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn write(&self, _msg: MessageBatchRef) -> Result<(), Error> {
+            self.write_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+        async fn write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error> {
+            self.batch_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.batch_len
+                .store(msgs.len() as u32, std::sync::atomic::Ordering::SeqCst);
+            if self.fail_batch.load(std::sync::atomic::Ordering::SeqCst) {
+                Err(Error::Process("counting output failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+        async fn close(&self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    /// Ack that records whether it was invoked.
+    struct CountingAck(std::sync::atomic::AtomicBool);
+    #[async_trait]
+    impl crate::input::Ack for CountingAck {
+        async fn ack(&self) -> Result<(), Error> {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn output_worker_calls_write_batch_once_per_ack_range() {
+        let output: Arc<CountingOutput> = Arc::new(CountingOutput::new());
+        let out_ref: Arc<dyn Output> = output.clone();
+        let counting = Arc::new(CountingAck(std::sync::atomic::AtomicBool::new(false)));
+        let ack: Arc<dyn crate::input::Ack> = counting.clone();
+        let msgs = vec![
+            Arc::new(sample_batch()) as MessageBatchRef,
+            Arc::new(sample_batch()),
+            Arc::new(sample_batch()),
+        ];
+
+        Stream::output(ProcessorData::Ok(msgs), &ack, &out_ref, None).await;
+
+        assert_eq!(
+            output.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "write_batch must be called exactly once per ack range"
+        );
+        assert_eq!(
+            output.batch_len.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "write_batch must receive all messages of the ack range"
+        );
+        assert_eq!(
+            output.write_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the output worker must route through write_batch, not write"
+        );
+        assert!(
+            counting.0.load(std::sync::atomic::Ordering::SeqCst),
+            "ack must fire on full success"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_batch_failure_withholds_ack() {
+        let output: Arc<CountingOutput> = Arc::new(CountingOutput::failing());
+        let out_ref: Arc<dyn Output> = output.clone();
+        let counting = Arc::new(CountingAck(std::sync::atomic::AtomicBool::new(false)));
+        let ack: Arc<dyn crate::input::Ack> = counting.clone();
+        let msgs = vec![Arc::new(sample_batch()) as MessageBatchRef];
+
+        Stream::output(ProcessorData::Ok(msgs), &ack, &out_ref, None).await;
+
+        assert_eq!(
+            output.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert!(
+            !counting.0.load(std::sync::atomic::Ordering::SeqCst),
+            "ack MUST be withheld when write_batch fails, so the WAL cursor does not advance and the range is replayed"
+        );
     }
 
     fn sample_batch() -> MessageBatch {

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -48,6 +48,7 @@ governor = { workspace = true, features = ["std"] }
 colored = { workspace = true }
 flume = { workspace = true }
 dashmap = { workspace = true }
+tempfile = { workspace = true }
 rumqttc = "0.25.1"
 
 # Kafka
@@ -107,5 +108,5 @@ url = "2.5.8"
 num_cpus = "1.17.0"
 
 [dev-dependencies]
-tempfile = { workspace = true }
 mockall = { workspace = true }
+wiremock = "0.6"

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -109,4 +109,6 @@ num_cpus = "1.17.0"
 
 [dev-dependencies]
 mockall = { workspace = true }
+serial_test = "4.0.1"
+testcontainers = "0.27.3"
 wiremock = "0.6"

--- a/crates/arkflow-plugin/src/buffer/join.rs
+++ b/crates/arkflow-plugin/src/buffer/join.rs
@@ -140,7 +140,7 @@ impl JoinOperation {
                 .unwrap_or(DEFAULT_BINARY_VALUE_FIELD),
         )?;
         let mut result =
-            codec.decode(result.into_iter().map(|x| x.to_vec()).collect::<Vec<_>>())?;
+            codec.decode(result.into_iter().map(|x| x.to_vec()).collect::<Vec<_>>()).await?;
         result.set_input_name(option);
         Ok(result)
     }

--- a/crates/arkflow-plugin/src/codec/debezium.rs
+++ b/crates/arkflow-plugin/src/codec/debezium.rs
@@ -1,0 +1,295 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+//! Debezium CDC codec.
+//!
+//! Decodes Debezium Envelope JSON (e.g. consumed from Kafka via the Kafka input's
+//! codec hook) into a columnar Arrow `MessageBatch`. Each event is flattened:
+//! the `after` (or `before` for deletes) fields become top-level columns, and the
+//! envelope metadata (`op`, `ts_ms`, `source_db`, `source_table`) plus the full
+//! `before`/`source` objects are attached as JSON text columns, so downstream SQL processors
+//! can route by `op` and inspect change values directly.
+//!
+//! CDC offset is NOT managed here: it is the Kafka input's ack-gated offset (see
+//! the `input-durability` capability). This codec only parses payloads.
+
+use async_trait::async_trait;
+use crate::component;
+use arkflow_core::codec::{Codec, CodecBuilder, Decoder, Encoder};
+use arkflow_core::component::{register_codec_metadata, ComponentMetadata};
+use arkflow_core::{Bytes, Error, MessageBatch, Resource};
+use datafusion::arrow;
+use serde_json::{Map, Value};
+use std::sync::Arc;
+
+/// Debezium Envelope JSON codec.
+pub struct DebeziumJsonCodec;
+
+#[async_trait]
+impl Encoder for DebeziumJsonCodec {
+    async fn encode(&self, batch: MessageBatch) -> Result<Vec<Bytes>, Error> {
+        // Encoding is not Debezium-specific; emit the Arrow batch as line-delimited
+        // JSON so the codec satisfies the `Codec` contract and stays round-trippable.
+        let mut buf = Vec::new();
+        let mut writer = arrow::json::LineDelimitedWriter::new(&mut buf);
+        writer
+            .write(&batch)
+            .map_err(|e| Error::Process(format!("Debezium codec encode error: {}", e)))?;
+        writer
+            .finish()
+            .map_err(|e| Error::Process(format!("Debezium codec encode finish error: {}", e)))?;
+        let json_str = String::from_utf8(buf)
+            .map_err(|e| Error::Process(format!("Conversion to UTF-8 failed: {}", e)))?;
+        Ok(json_str.lines().map(|s| s.as_bytes().to_vec()).collect())
+    }
+}
+
+#[async_trait]
+impl Decoder for DebeziumJsonCodec {
+    async fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
+        let mut json_data: Vec<u8> = Vec::new();
+        for bytes in &b {
+            let envelope: Value = serde_json::from_slice(bytes)
+                .map_err(|e| Error::Process(format!("Invalid Debezium envelope JSON: {}", e)))?;
+            let row = flatten_envelope(envelope);
+            let line = serde_json::to_vec(&row)
+                .map_err(|e| Error::Process(format!("Failed to serialize flattened row: {}", e)))?;
+            json_data.extend_from_slice(&line);
+            json_data.push(b'\n');
+        }
+        let record_batch = component::json::try_to_arrow(&json_data, None)?;
+        Ok(MessageBatch::new_arrow(record_batch))
+    }
+}
+
+/// Flatten a Debezium Envelope into a single row object:
+/// - business fields from `after` (or `before` when `after` is null, e.g. deletes)
+///   are promoted to the top level;
+/// - `op`, `ts_ms`, `source_db`, `source_table` are added as top-level columns;
+/// - the full `before` and `source` objects are preserved as JSON text columns.
+fn flatten_envelope(envelope: Value) -> Value {
+    let op = envelope.get("op").cloned().unwrap_or(Value::Null);
+    let ts_ms = envelope.get("ts_ms").cloned().unwrap_or(Value::Null);
+    let source = envelope.get("source").cloned().unwrap_or(Value::Null);
+    let before = envelope.get("before").cloned().unwrap_or(Value::Null);
+    let after = envelope.get("after").cloned().unwrap_or(Value::Null);
+
+    // Business payload: prefer `after`; fall back to `before` for deletes / when
+    // `after` is null. Clone `before` here so the original is still available below
+    // for the preserved `before` column.
+    let business = if after.is_object() {
+        after
+    } else if before.is_object() {
+        before.clone()
+    } else {
+        Value::Null
+    };
+
+    let mut row = match business {
+        Value::Object(m) => m,
+        _ => Map::new(),
+    };
+
+    let (source_db, source_table) = match &source {
+        Value::Object(s) => (
+            s.get("db").cloned().unwrap_or(Value::Null),
+            s.get("table").cloned().unwrap_or(Value::Null),
+        ),
+        _ => (Value::Null, Value::Null),
+    };
+
+    // Preserve the full `before`/`source` as JSON text columns. The Arrow JSON
+    // reader's single-pass schema inference cannot reconcile a null-vs-object mix
+    // within a batch (e.g. `before` is null on inserts but an object on updates),
+    // so we serialize them to stable UTF-8 columns; downstream SQL can use JSON
+    // functions to inspect them. The most-used source fields (`source_db`,
+    // `source_table`) are already promoted to top-level scalar columns above.
+    let before_json = serde_json::to_string(&before).unwrap_or_else(|_| "null".to_string());
+    let source_json = serde_json::to_string(&source).unwrap_or_else(|_| "null".to_string());
+    row.insert("op".into(), op);
+    row.insert("ts_ms".into(), ts_ms);
+    row.insert("source_db".into(), source_db);
+    row.insert("source_table".into(), source_table);
+    row.insert("before".into(), Value::String(before_json));
+    row.insert("source".into(), Value::String(source_json));
+
+    Value::Object(row)
+}
+
+struct DebeziumJsonCodecBuilder;
+
+impl CodecBuilder for DebeziumJsonCodecBuilder {
+    fn build(
+        &self,
+        _name: Option<&String>,
+        _config: &Option<Value>,
+        _resource: &Resource,
+    ) -> Result<Arc<dyn Codec>, Error> {
+        Ok(Arc::new(DebeziumJsonCodec))
+    }
+}
+
+pub(crate) fn init() -> Result<(), Error> {
+    arkflow_core::codec::register_codec_builder("debezium_json", Arc::new(DebeziumJsonCodecBuilder))?;
+    register_codec_metadata(
+        ComponentMetadata::with_schema(
+            "debezium_json",
+            "Decodes Debezium CDC Envelope JSON (before/after/op/source/ts_ms) into a columnar \
+             Arrow batch; attach to a Kafka input consuming a Debezium topic. CDC offset is the \
+             Kafka input's ack-gated offset.",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {}
+            }),
+        )
+        .with_optional(),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::AsArray;
+
+    async fn decode_one(json: &str) -> MessageBatch {
+        let codec = DebeziumJsonCodec;
+        codec
+            .decode(vec![json.as_bytes().to_vec()])
+            .await
+            .unwrap()
+    }
+
+    fn str_col<'a>(batch: &'a MessageBatch, name: &str, row: usize) -> &'a str {
+        let col = batch
+            .record_batch()
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("column `{}` must exist", name));
+        col.as_string::<i32>().value(row)
+    }
+
+    #[tokio::test]
+    async fn test_create_event() {
+        let batch = decode_one(
+            r#"{"before":null,"after":{"id":1,"name":"alice"},"op":"c","ts_ms":1700000000000,"source":{"db":"shop","table":"users"}}"#,
+        )
+        .await;
+        assert_eq!(batch.len(), 1);
+        assert_eq!(str_col(&batch, "op", 0), "c");
+        assert_eq!(str_col(&batch, "name", 0), "alice");
+        assert_eq!(str_col(&batch, "source_db", 0), "shop");
+        assert_eq!(str_col(&batch, "source_table", 0), "users");
+    }
+
+    #[tokio::test]
+    async fn test_update_event_after_wins() {
+        let batch = decode_one(
+            r#"{"before":{"id":1,"name":"alice"},"after":{"id":1,"name":"ALICE"},"op":"u","ts_ms":1700000000001,"source":{"db":"shop","table":"users"}}"#,
+        )
+        .await;
+        assert_eq!(batch.len(), 1);
+        assert_eq!(str_col(&batch, "op", 0), "u");
+        assert_eq!(str_col(&batch, "name", 0), "ALICE"); // after takes precedence
+    }
+
+    #[tokio::test]
+    async fn test_delete_event_uses_before() {
+        // after is null -> business fields come from before; must not error.
+        let batch = decode_one(
+            r#"{"before":{"id":1,"name":"alice"},"after":null,"op":"d","ts_ms":1700000000002,"source":{"db":"shop","table":"users"}}"#,
+        )
+        .await;
+        assert_eq!(batch.len(), 1);
+        assert_eq!(str_col(&batch, "op", 0), "d");
+        assert_eq!(str_col(&batch, "name", 0), "alice"); // from before
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_read_event() {
+        let batch = decode_one(
+            r#"{"before":null,"after":{"id":2,"name":"bob"},"op":"r","ts_ms":1700000000003,"source":{"db":"shop","table":"users"}}"#,
+        )
+        .await;
+        assert_eq!(batch.len(), 1);
+        assert_eq!(str_col(&batch, "op", 0), "r");
+        assert_eq!(str_col(&batch, "name", 0), "bob");
+    }
+
+    #[tokio::test]
+    async fn test_missing_source_is_tolerated() {
+        // No `source` field -> should not error; op still decoded.
+        let batch =
+            decode_one(r#"{"before":null,"after":{"id":3,"name":"c"},"op":"c","ts_ms":1}"#).await;
+        assert_eq!(batch.len(), 1);
+        assert_eq!(str_col(&batch, "op", 0), "c");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_json_errors() {
+        let codec = DebeziumJsonCodec;
+        let result = codec.decode(vec![b"not json".to_vec()]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_events_in_one_batch() {
+        let codec = DebeziumJsonCodec;
+        let data = vec![
+            br#"{"before":null,"after":{"id":1,"name":"a"},"op":"c","ts_ms":1,"source":{"db":"s","table":"t"}}"#.to_vec(),
+            br#"{"before":{"id":1,"name":"a"},"after":{"id":2,"name":"b"},"op":"u","ts_ms":2,"source":{"db":"s","table":"t"}}"#.to_vec(),
+        ];
+        let batch = codec.decode(data).await.unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(str_col(&batch, "op", 0), "c");
+        assert_eq!(str_col(&batch, "op", 1), "u");
+        assert_eq!(str_col(&batch, "name", 1), "b"); // after wins on update
+    }
+
+    #[tokio::test]
+    async fn test_before_and_source_are_json_text() {
+        let batch = decode_one(
+            r#"{"before":{"id":1,"name":"alice"},"after":{"id":1,"name":"ALICE"},"op":"u","ts_ms":1,"source":{"db":"shop","table":"users"}}"#,
+        )
+        .await;
+        let before = str_col(&batch, "before", 0);
+        assert!(before.contains("\"name\":\"alice\"")); // full before preserved as JSON text
+        let source = str_col(&batch, "source", 0);
+        assert!(source.contains("\"db\":\"shop\""));
+    }
+
+    #[tokio::test]
+    async fn test_ts_ms_extracted() {
+        use datafusion::arrow::datatypes::Int64Type;
+        let batch = decode_one(
+            r#"{"before":null,"after":{"id":1},"op":"c","ts_ms":1700000000000,"source":{"db":"s","table":"t"}}"#,
+        )
+        .await;
+        let ts = batch
+            .record_batch()
+            .column_by_name("ts_ms")
+            .expect("ts_ms column");
+        assert_eq!(ts.as_primitive::<Int64Type>().value(0), 1700000000000);
+    }
+
+    #[tokio::test]
+    async fn test_builder() {
+        let builder = DebeziumJsonCodecBuilder;
+        let resource = Resource {
+            temporary: std::collections::HashMap::new(),
+            input_names: std::cell::RefCell::new(Vec::new()),
+        };
+        let result = builder.build(None, &None, &resource);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/arkflow-plugin/src/codec/json.rs
+++ b/crates/arkflow-plugin/src/codec/json.rs
@@ -11,6 +11,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+use async_trait::async_trait;
 use crate::component;
 use arkflow_core::codec::{Codec, CodecBuilder, Decoder, Encoder};
 use arkflow_core::component::{register_codec_metadata, ComponentMetadata};
@@ -21,8 +22,9 @@ use std::sync::Arc;
 
 struct JsonCodec;
 
+#[async_trait]
 impl Encoder for JsonCodec {
-    fn encode(&self, batch: MessageBatch) -> Result<Vec<Bytes>, Error> {
+    async fn encode(&self, batch: MessageBatch) -> Result<Vec<Bytes>, Error> {
         let mut buf = Vec::new();
         let mut writer = arrow::json::LineDelimitedWriter::new(&mut buf);
         writer
@@ -38,8 +40,9 @@ impl Encoder for JsonCodec {
     }
 }
 
+#[async_trait]
 impl Decoder for JsonCodec {
-    fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
+    async fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
         let json_data: Vec<u8> = b.join(b"\n" as &[u8]);
 
         let arrow = component::json::try_to_arrow(&json_data, None)?;
@@ -86,8 +89,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_json_codec_encode() {
+    #[tokio::test]
+    async fn test_json_codec_encode() {
         let codec = JsonCodec;
 
         // Create a simple message batch
@@ -97,7 +100,7 @@ mod tests {
         ])
         .unwrap();
 
-        let result = codec.encode(batch);
+        let result = codec.encode(batch).await;
         assert!(result.is_ok());
         let encoded = result.unwrap();
 
@@ -105,8 +108,8 @@ mod tests {
         assert!(!encoded.is_empty());
     }
 
-    #[test]
-    fn test_json_codec_decode() {
+    #[tokio::test]
+    async fn test_json_codec_decode() {
         let codec = JsonCodec;
 
         let json_data = vec![
@@ -114,7 +117,7 @@ mod tests {
             br#"{"name":"Bob","age":25}"#.to_vec(),
         ];
 
-        let result = codec.decode(json_data);
+        let result = codec.decode(json_data).await;
         assert!(result.is_ok());
         let batch = result.unwrap();
 
@@ -122,8 +125,8 @@ mod tests {
         assert!(batch.len() > 0);
     }
 
-    #[test]
-    fn test_json_codec_encode_decode_roundtrip() {
+    #[tokio::test]
+    async fn test_json_codec_encode_decode_roundtrip() {
         let codec = JsonCodec;
 
         let original_data = vec![
@@ -132,36 +135,36 @@ mod tests {
         ];
 
         // Decode
-        let batch = codec.decode(original_data.clone()).unwrap();
+        let batch = codec.decode(original_data.clone()).await.unwrap();
 
         // Encode
-        let encoded = codec.encode(batch.clone()).unwrap();
+        let encoded = codec.encode(batch.clone()).await.unwrap();
 
         // Decode again
-        let final_batch = codec.decode(encoded).unwrap();
+        let final_batch = codec.decode(encoded).await.unwrap();
 
         // Both batches should have the same number of rows
         assert_eq!(batch.len(), final_batch.len());
     }
 
-    #[test]
-    fn test_json_codec_decode_empty() {
+    #[tokio::test]
+    async fn test_json_codec_decode_empty() {
         let codec = JsonCodec;
-        let result = codec.decode(vec![]);
+        let result = codec.decode(vec![]).await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_json_codec_decode_invalid_json() {
+    #[tokio::test]
+    async fn test_json_codec_decode_invalid_json() {
         let codec = JsonCodec;
         let invalid_data = vec![b"{invalid json}".to_vec()];
-        let result = codec.decode(invalid_data);
+        let result = codec.decode(invalid_data).await;
         // Should handle invalid JSON gracefully or return error
         assert!(result.is_err() || result.is_ok());
     }
 
-    #[test]
-    fn test_json_codec_builder() {
+    #[tokio::test]
+    async fn test_json_codec_builder() {
         let builder = JsonCodecBuilder;
         let result = builder.build(
             Some(&"test-codec".to_string()),
@@ -172,8 +175,8 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_json_codec_builder_with_config() {
+    #[tokio::test]
+    async fn test_json_codec_builder_with_config() {
         let builder = JsonCodecBuilder;
         let config = serde_json::json!({});
 
@@ -186,20 +189,20 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_json_codec_encode_single_message() {
+    #[tokio::test]
+    async fn test_json_codec_encode_single_message() {
         let codec = JsonCodec;
         let batch = MessageBatch::new_binary(vec![br#"{"test":"data"}"#.to_vec()]).unwrap();
 
-        let result = codec.encode(batch);
+        let result = codec.encode(batch).await;
         assert!(result.is_ok());
         let encoded = result.unwrap();
 
         assert!(!encoded.is_empty());
     }
 
-    #[test]
-    fn test_json_codec_decode_complex_json() {
+    #[tokio::test]
+    async fn test_json_codec_decode_complex_json() {
         let codec = JsonCodec;
 
         let complex_json = vec![
@@ -207,7 +210,7 @@ mod tests {
             br#"{"user":{"name":"Bob","tags":["user"]},"active":false}"#.to_vec(),
         ];
 
-        let result = codec.decode(complex_json);
+        let result = codec.decode(complex_json).await;
         assert!(result.is_ok());
         let batch = result.unwrap();
 

--- a/crates/arkflow-plugin/src/codec/mod.rs
+++ b/crates/arkflow-plugin/src/codec/mod.rs
@@ -15,10 +15,14 @@ use arkflow_core::Error;
 
 pub mod json;
 pub mod protobuf;
+pub mod debezium;
+pub mod schema_registry;
 
 pub fn init() -> Result<(), Error> {
     json::init()?;
     protobuf::init()?;
+    debezium::init()?;
+    schema_registry::init()?;
     Ok(())
 }
 

--- a/crates/arkflow-plugin/src/codec/protobuf.rs
+++ b/crates/arkflow-plugin/src/codec/protobuf.rs
@@ -24,6 +24,7 @@
 //! Nested message / repeated / map / oneof / proto3 optional fields are NOT
 //! supported and produce an error.
 
+use async_trait::async_trait;
 use crate::component::protobuf::{
     arrow_to_protobuf, parse_proto_file, protobuf_to_arrow, ProtobufConfig,
 };
@@ -88,14 +89,16 @@ impl ProtobufCodec {
     }
 }
 
+#[async_trait]
 impl Encoder for ProtobufCodec {
-    fn encode(&self, b: MessageBatch) -> Result<Vec<Bytes>, Error> {
+    async fn encode(&self, b: MessageBatch) -> Result<Vec<Bytes>, Error> {
         arrow_to_protobuf(&self.descriptor, &b)
     }
 }
 
+#[async_trait]
 impl Decoder for ProtobufCodec {
-    fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
+    async fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
         let mut batches = Vec::with_capacity(b.len());
 
         for data in b {
@@ -171,8 +174,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_protobuf_codec_config_deserialization() {
+    #[tokio::test]
+    async fn test_protobuf_codec_config_deserialization() {
         let config_json = serde_json::json!({
             "proto_inputs": ["/path/to/file.proto"],
             "message_type": "MyMessage"
@@ -184,8 +187,8 @@ mod tests {
         assert!(config.proto_includes.is_none());
     }
 
-    #[test]
-    fn test_protobuf_codec_config_with_includes() {
+    #[tokio::test]
+    async fn test_protobuf_codec_config_with_includes() {
         let config_json = serde_json::json!({
             "proto_inputs": ["/path/to/file.proto"],
             "proto_includes": ["/include/path"],
@@ -199,8 +202,8 @@ mod tests {
         assert_eq!(config.proto_includes.unwrap(), vec!["/include/path"]);
     }
 
-    #[test]
-    fn test_protobuf_codec_builder_with_valid_config() {
+    #[tokio::test]
+    async fn test_protobuf_codec_builder_with_valid_config() {
         let config_json = serde_json::json!({
             "proto_inputs": ["/path/to/file.proto"],
             "message_type": "MyMessage"
@@ -212,8 +215,8 @@ mod tests {
         assert_eq!(config.message_type, "MyMessage");
     }
 
-    #[test]
-    fn test_protobuf_codec_builder_without_config() {
+    #[tokio::test]
+    async fn test_protobuf_codec_builder_without_config() {
         let builder = ProtobufCodecBuilder;
         let result = builder.build(
             Some(&"test-codec".to_string()),
@@ -225,8 +228,8 @@ mod tests {
         assert!(matches!(result, Err(Error::Config(_))));
     }
 
-    #[test]
-    fn test_protobuf_codec_config_impl() {
+    #[tokio::test]
+    async fn test_protobuf_codec_config_impl() {
         let config = ProtobufCodecConfig {
             proto_inputs: vec!["test.proto".to_string()],
             proto_includes: Some(vec!["/include".to_string()]),
@@ -237,8 +240,8 @@ mod tests {
         assert_eq!(config.proto_includes(), &Some(vec!["/include".to_string()]));
     }
 
-    #[test]
-    fn test_protobuf_codec_builder_invalid_json() {
+    #[tokio::test]
+    async fn test_protobuf_codec_builder_invalid_json() {
         let builder = ProtobufCodecBuilder;
         let invalid_json = serde_json::json!({
             "proto_inputs": "should_be_array"
@@ -278,8 +281,8 @@ message TestMessage {
         Ok((dir, proto_dir))
     }
 
-    #[test]
-    fn test_codec_round_trip() -> Result<(), Error> {
+    #[tokio::test]
+    async fn test_codec_round_trip() -> Result<(), Error> {
         let (_x, proto_dir) = create_test_proto_file()?;
         let config = serde_json::json!({
             "proto_inputs": [proto_dir.to_string_lossy()],
@@ -303,9 +306,9 @@ message TestMessage {
         .map_err(|e| Error::Process(format!("Failed to create record batch: {}", e)))?;
         let original = MessageBatch::new_arrow(rb);
 
-        let encoded = codec.encode(original)?;
+        let encoded = codec.encode(original).await?;
         assert_eq!(encoded.len(), 1, "one row → one encoded message");
-        let decoded = codec.decode(encoded)?;
+        let decoded = codec.decode(encoded).await?;
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded.column(0).data_type(), &DataType::Int64);
 

--- a/crates/arkflow-plugin/src/codec/schema_registry.rs
+++ b/crates/arkflow-plugin/src/codec/schema_registry.rs
@@ -1,0 +1,445 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+//! Schema Registry codec.
+//!
+//! Decodes Confluent wire-format Protobuf messages by resolving the schema id
+//! via a `SchemaResolver` (default: Confluent Schema Registry REST). The wire
+//! format is `[0x00 magic][4-byte big-endian schema id][payload]`. Descriptors
+//! are cached per id so each schema version is fetched at most once.
+
+use crate::component::protobuf::{parse_proto_source, protobuf_to_arrow};
+use async_trait::async_trait;
+use arkflow_core::codec::{Codec, CodecBuilder, Decoder, Encoder};
+use arkflow_core::component::{register_codec_metadata, ComponentMetadata};
+use arkflow_core::{Bytes, Error, MessageBatch, Resource};
+use dashmap::DashMap;
+use datafusion::arrow;
+use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::record_batch::RecordBatch;
+use prost_reflect::MessageDescriptor;
+use serde::Deserialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+/// Resolve a Protobuf schema string by Confluent schema id.
+#[async_trait]
+pub trait SchemaResolver: Send + Sync {
+    async fn fetch_schema(&self, id: u32) -> Result<String, Error>;
+}
+
+/// Schema Registry codec: decodes Confluent wire-format Protobuf messages by
+/// resolving the schema id via a `SchemaResolver` and caching the descriptor.
+pub struct SchemaRegistryCodec {
+    message_type: String,
+    resolver: Arc<dyn SchemaResolver>,
+    cache: DashMap<u32, MessageDescriptor>,
+}
+
+impl SchemaRegistryCodec {
+    pub fn new(message_type: String, resolver: Arc<dyn SchemaResolver>) -> Self {
+        Self {
+            message_type,
+            resolver,
+            cache: DashMap::new(),
+        }
+    }
+
+    async fn resolve_descriptor(&self, id: u32) -> Result<MessageDescriptor, Error> {
+        if let Some(desc) = self.cache.get(&id) {
+            return Ok(desc.clone());
+        }
+        let schema = self.resolver.fetch_schema(id).await?;
+        let descriptor = parse_proto_source(&schema, &self.message_type)?;
+        self.cache.insert(id, descriptor.clone());
+        Ok(descriptor)
+    }
+}
+
+#[async_trait]
+impl Encoder for SchemaRegistryCodec {
+    async fn encode(&self, batch: MessageBatch) -> Result<Vec<Bytes>, Error> {
+        // Encoding is not registry-specific; emit Arrow as line-delimited JSON to
+        // satisfy the `Codec` contract and stay round-trippable.
+        let mut buf = Vec::new();
+        let mut writer = arrow::json::LineDelimitedWriter::new(&mut buf);
+        writer
+            .write(&batch)
+            .map_err(|e| Error::Process(format!("Schema registry codec encode error: {}", e)))?;
+        writer
+            .finish()
+            .map_err(|e| Error::Process(format!("Schema registry codec encode finish error: {}", e)))?;
+        let s = String::from_utf8(buf)
+            .map_err(|e| Error::Process(format!("UTF-8 conversion failed: {}", e)))?;
+        Ok(s.lines().map(|l| l.as_bytes().to_vec()).collect())
+    }
+}
+
+#[async_trait]
+impl Decoder for SchemaRegistryCodec {
+    async fn decode(&self, b: Vec<Bytes>) -> Result<MessageBatch, Error> {
+        let mut batches = Vec::with_capacity(b.len());
+        for msg in b {
+            let (id, payload) = parse_wire_format(&msg)?;
+            let descriptor = self.resolve_descriptor(id).await?;
+            batches.push(protobuf_to_arrow(&descriptor, payload)?);
+        }
+        if batches.is_empty() {
+            return Ok(MessageBatch::new_arrow(RecordBatch::new_empty(Arc::new(
+                Schema::empty(),
+            ))));
+        }
+        let schema = batches[0].schema();
+        let merged = arrow::compute::concat_batches(&schema, &batches)
+            .map_err(|e| Error::Process(format!("Batch merge failed: {}", e)))?;
+        Ok(MessageBatch::new_arrow(merged))
+    }
+}
+
+/// Parse Confluent wire format: `[0x00 magic][4-byte big-endian schema id][payload]`.
+fn parse_wire_format(msg: &[u8]) -> Result<(u32, &[u8]), Error> {
+    if msg.len() < 5 {
+        return Err(Error::Process(
+            "Message too short for Confluent wire format".to_string(),
+        ));
+    }
+    if msg[0] != 0x00 {
+        return Err(Error::Process(format!(
+            "Invalid Confluent magic byte: 0x{:02X}",
+            msg[0]
+        )));
+    }
+    let id = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]);
+    Ok((id, &msg[5..]))
+}
+
+// ===== RestSchemaResolver (Confluent REST, reqwest async) =====
+
+/// Authentication for the Schema Registry.
+pub enum Auth {
+    Basic(String, String),
+    Bearer(String),
+}
+
+/// Resolves schemas from a Confluent Schema Registry via REST.
+pub struct RestSchemaResolver {
+    client: reqwest::Client,
+    base_url: String,
+    auth: Option<Auth>,
+}
+
+impl RestSchemaResolver {
+    pub fn new(base_url: String, auth: Option<Auth>) -> Result<Self, Error> {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| Error::Config(format!("Failed to build HTTP client: {}", e)))?;
+        Ok(Self {
+            client,
+            base_url,
+            auth,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct SchemaResponse {
+    schema: String,
+    #[serde(rename = "schemaType", default)]
+    schema_type: Option<String>,
+}
+
+#[async_trait]
+impl SchemaResolver for RestSchemaResolver {
+    async fn fetch_schema(&self, id: u32) -> Result<String, Error> {
+        let url = format!(
+            "{}/schemas/ids/{}",
+            self.base_url.trim_end_matches('/'),
+            id
+        );
+        let mut req = self
+            .client
+            .get(&url)
+            .header("Accept", "application/vnd.schemaregistry.v1+json");
+        if let Some(auth) = &self.auth {
+            req = match auth {
+                Auth::Basic(u, p) => req.basic_auth(u, Some(p)),
+                Auth::Bearer(t) => req.bearer_auth(t),
+            };
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| Error::Process(format!("Schema Registry request failed: {}", e)))?;
+        if !resp.status().is_success() {
+            return Err(Error::Process(format!(
+                "Schema Registry returned status {}",
+                resp.status()
+            )));
+        }
+        let body: SchemaResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::Process(format!("Schema Registry response parse failed: {}", e)))?;
+        if let Some(t) = &body.schema_type {
+            if t.to_uppercase() != "PROTOBUF" {
+                return Err(Error::Process(format!(
+                    "Unsupported schema type: {} (only PROTOBUF supported)",
+                    t
+                )));
+            }
+        }
+        Ok(body.schema)
+    }
+}
+
+// ===== Config + Builder + init =====
+
+#[derive(Deserialize)]
+struct SchemaRegistryCodecConfig {
+    registry_url: String,
+    message_type: String,
+    #[serde(default)]
+    auth: Option<AuthConfig>,
+}
+
+#[derive(Deserialize)]
+struct AuthConfig {
+    #[serde(rename = "type")]
+    auth_type: String,
+    username: Option<String>,
+    password: Option<String>,
+    token: Option<String>,
+}
+
+struct SchemaRegistryCodecBuilder;
+
+impl CodecBuilder for SchemaRegistryCodecBuilder {
+    fn build(
+        &self,
+        _name: Option<&String>,
+        config: &Option<Value>,
+        _resource: &Resource,
+    ) -> Result<Arc<dyn Codec>, Error> {
+        let config = config
+            .as_ref()
+            .ok_or_else(|| Error::Config("schema_registry codec configuration is missing".to_string()))?;
+        let config: SchemaRegistryCodecConfig = serde_json::from_value(config.clone())?;
+        let auth = match config.auth {
+            None => None,
+            Some(a) => Some(match a.auth_type.as_str() {
+                "basic" => Auth::Basic(a.username.unwrap_or_default(), a.password.unwrap_or_default()),
+                "bearer" => Auth::Bearer(a.token.unwrap_or_default()),
+                other => return Err(Error::Config(format!("Unsupported auth type: {}", other))),
+            }),
+        };
+        let resolver = Arc::new(RestSchemaResolver::new(config.registry_url, auth)?);
+        Ok(Arc::new(SchemaRegistryCodec::new(config.message_type, resolver)))
+    }
+}
+
+pub(crate) fn init() -> Result<(), Error> {
+    arkflow_core::codec::register_codec_builder("schema_registry", Arc::new(SchemaRegistryCodecBuilder))?;
+    register_codec_metadata(
+        ComponentMetadata::with_schema(
+            "schema_registry",
+            "Decodes Confluent wire-format Protobuf messages by resolving the schema id from a Schema Registry.",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "registry_url": {"type": "string", "description": "Confluent Schema Registry base URL."},
+                    "message_type": {"type": "string", "description": "Fully-qualified Protobuf message type."},
+                    "auth": {"type": "object", "description": "Optional registry authentication.", "properties": {
+                        "type": {"type": "string", "enum": ["basic", "bearer"]},
+                        "username": {"type": "string"},
+                        "password": {"type": "string"},
+                        "token": {"type": "string"}
+                    }}
+                },
+                "required": ["registry_url", "message_type"]
+            }),
+        ),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const TEST_SCHEMA: &str = "syntax = \"proto3\";\npackage test;\nmessage M { int64 id = 1; }";
+
+    /// Payload for `M { id = 42 }`: field 1 (int64, varint), tag=0x08, value=0x2A.
+    fn payload_id_42() -> Vec<u8> {
+        vec![0x08, 0x2A]
+    }
+
+    fn wire(id: u32, payload: &[u8]) -> Vec<u8> {
+        let mut m = vec![0x00];
+        m.extend_from_slice(&id.to_be_bytes());
+        m.extend_from_slice(payload);
+        m
+    }
+
+    struct InMemorySchemaResolver {
+        schemas: HashMap<u32, String>,
+        fetch_count: AtomicU32,
+    }
+    impl InMemorySchemaResolver {
+        fn new(map: HashMap<u32, String>) -> Self {
+            Self {
+                schemas: map,
+                fetch_count: AtomicU32::new(0),
+            }
+        }
+        fn fetches(&self) -> u32 {
+            self.fetch_count.load(Ordering::SeqCst)
+        }
+    }
+    #[async_trait]
+    impl SchemaResolver for InMemorySchemaResolver {
+        async fn fetch_schema(&self, id: u32) -> Result<String, Error> {
+            self.fetch_count.fetch_add(1, Ordering::SeqCst);
+            self.schemas
+                .get(&id)
+                .cloned()
+                .ok_or_else(|| Error::Process(format!("schema id {} not in test resolver", id)))
+        }
+    }
+
+    fn build_codec(resolver: Arc<dyn SchemaResolver>) -> SchemaRegistryCodec {
+        SchemaRegistryCodec::new("test.M".to_string(), resolver)
+    }
+
+    #[test]
+    fn test_parse_wire_format_valid() {
+        let msg = wire(1, &[0x08, 0x2A]);
+        let (id, payload) = parse_wire_format(&msg).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(payload, &[0x08, 0x2A]);
+    }
+
+    #[test]
+    fn test_parse_wire_format_bad_magic() {
+        let mut bad = wire(1, &[]);
+        bad[0] = 0x01;
+        assert!(parse_wire_format(&bad).is_err());
+    }
+
+    #[test]
+    fn test_parse_wire_format_too_short() {
+        assert!(parse_wire_format(&[0x00, 0x00, 0x00]).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_decode_single() {
+        let resolver = Arc::new(InMemorySchemaResolver::new(HashMap::from([(
+            1u32,
+            TEST_SCHEMA.to_string(),
+        )])));
+        let codec = build_codec(resolver.clone());
+        let batch = codec.decode(vec![wire(1, &payload_id_42())]).await.unwrap();
+        assert_eq!(batch.len(), 1);
+        use datafusion::arrow::array::AsArray;
+        use datafusion::arrow::datatypes::Int64Type;
+        let id_col = batch
+            .record_batch()
+            .column_by_name("id")
+            .expect("id column");
+        assert_eq!(id_col.as_primitive::<Int64Type>().value(0), 42);
+        assert_eq!(resolver.fetches(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hits() {
+        let resolver = Arc::new(InMemorySchemaResolver::new(HashMap::from([(
+            1u32,
+            TEST_SCHEMA.to_string(),
+        )])));
+        let codec = build_codec(resolver.clone());
+        let batch = codec
+            .decode(vec![wire(1, &payload_id_42()), wire(1, &payload_id_42())])
+            .await
+            .unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(resolver.fetches(), 1); // only the first fetches
+    }
+
+    #[tokio::test]
+    async fn test_multi_version_each_resolves() {
+        // two ids, same (compatible) schema; each resolves its own descriptor.
+        let resolver = Arc::new(InMemorySchemaResolver::new(HashMap::from([
+            (1u32, TEST_SCHEMA.to_string()),
+            (2u32, TEST_SCHEMA.to_string()),
+        ])));
+        let codec = build_codec(resolver.clone());
+        let batch = codec
+            .decode(vec![wire(1, &payload_id_42()), wire(2, &payload_id_42())])
+            .await
+            .unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(resolver.fetches(), 2); // both ids resolved
+    }
+
+    #[tokio::test]
+    async fn test_resolver_error() {
+        let resolver = Arc::new(InMemorySchemaResolver::new(HashMap::new())); // empty -> all error
+        let codec = build_codec(resolver);
+        let result = codec.decode(vec![wire(99, &payload_id_42())]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_rest_resolver_basic_auth() {
+        // base64("user:pass") == "dXNlcjpwYXNz"
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/schemas/ids/1"))
+            .and(header("authorization", "Basic dXNlcjpwYXNz"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"schema": "syntax = \"proto3\"; message M {}", "schemaType": "PROTOBUF"}),
+            ))
+            .mount(&server)
+            .await;
+        let resolver = RestSchemaResolver::new(
+            server.uri(),
+            Some(Auth::Basic("user".into(), "pass".into())),
+        )
+        .unwrap();
+        let schema = resolver.fetch_schema(1).await.unwrap();
+        assert!(schema.contains("message M"));
+    }
+
+    #[tokio::test]
+    async fn test_rest_resolver_bearer_auth() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/schemas/ids/2"))
+            .and(header("authorization", "Bearer tok"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"schema": "syntax = \"proto3\"; message M {}"})),
+            )
+            .mount(&server)
+            .await;
+        let resolver =
+            RestSchemaResolver::new(server.uri(), Some(Auth::Bearer("tok".into()))).unwrap();
+        let schema = resolver.fetch_schema(2).await.unwrap();
+        assert!(schema.contains("message M"));
+    }
+}

--- a/crates/arkflow-plugin/src/component/protobuf.rs
+++ b/crates/arkflow-plugin/src/component/protobuf.rs
@@ -123,6 +123,51 @@ pub fn parse_proto_file<T: ProtobufConfig>(config: &T) -> Result<FileDescriptorS
     Ok(file_descriptor_set)
 }
 
+/// Parse a Protobuf schema from a source string (e.g. obtained from a Schema Registry)
+/// and return the `MessageDescriptor` for `message_type`. Used by codecs that resolve
+/// schemas dynamically at runtime rather than from local files.
+pub fn parse_proto_source(schema: &str, message_type: &str) -> Result<MessageDescriptor, Error> {
+    let dir = tempfile::tempdir()
+        .map_err(|e| Error::Config(format!("Failed to create temp dir: {}", e)))?;
+    let proto_path = dir.path().join("registry_schema.proto");
+    fs::write(&proto_path, schema)
+        .map_err(|e| Error::Config(format!("Failed to write proto source: {}", e)))?;
+
+    let proto_input = proto_path
+        .to_str()
+        .ok_or_else(|| Error::Config("Invalid temp proto path".to_string()))?
+        .to_string();
+    let include_dir = dir
+        .path()
+        .to_str()
+        .ok_or_else(|| Error::Config("Invalid temp include path".to_string()))?
+        .to_string();
+
+    let file_descriptor_protos = protobuf_parse::Parser::new()
+        .pure()
+        .inputs(&[proto_input])
+        .includes(&[include_dir])
+        .parse_and_typecheck()
+        .map_err(|e| Error::Config(format!("Failed to parse proto source: {}", e)))?
+        .file_descriptors;
+
+    let mut file_descriptor_set = FileDescriptorSet { file: Vec::new() };
+    for proto in file_descriptor_protos {
+        let proto_bytes = proto
+            .write_to_bytes()
+            .map_err(|e| Error::Config(format!("Failed to serialize FileDescriptorProto: {}", e)))?;
+        let prost_proto =
+            prost_reflect::prost_types::FileDescriptorProto::decode(proto_bytes.as_slice())
+                .map_err(|e| Error::Config(format!("Failed to convert FileDescriptorProto: {}", e)))?;
+        file_descriptor_set.file.push(prost_proto);
+    }
+
+    let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(file_descriptor_set)
+        .map_err(|e| Error::Config(format!("Failed to create descriptor pool: {}", e)))?;
+    pool.get_message_by_name(message_type)
+        .ok_or_else(|| Error::Config(format!("Message type not found in schema: {}", message_type)))
+}
+
 /// Convert Protobuf data to Arrow format
 ///
 /// The schema is driven by the message descriptor's full field set (every field

--- a/crates/arkflow-plugin/src/input/codec_helper.rs
+++ b/crates/arkflow-plugin/src/input/codec_helper.rs
@@ -27,12 +27,12 @@ use std::sync::Arc;
 /// # Returns
 /// * `Ok(MessageBatch)` - Decoded or binary-wrapped message batch
 /// * `Err(Error)` - If codec application fails
-pub fn apply_codec_to_payload(
+pub async fn apply_codec_to_payload(
     payload: &[u8],
     codec: &Option<Arc<dyn Codec>>,
 ) -> Result<MessageBatch, Error> {
     if let Some(c) = codec {
-        c.decode(vec![payload.to_vec()])
+        c.decode(vec![payload.to_vec()]).await
     } else {
         MessageBatch::new_binary(vec![payload.to_vec()])
     }
@@ -47,12 +47,12 @@ pub fn apply_codec_to_payload(
 /// # Returns
 /// * `Ok(MessageBatch)` - Decoded or binary-wrapped message batch
 /// * `Err(Error)` - If codec application fails
-pub fn apply_codec_to_payloads(
+pub async fn apply_codec_to_payloads(
     payloads: Vec<Bytes>,
     codec: &Option<Arc<dyn Codec>>,
 ) -> Result<MessageBatch, Error> {
     if let Some(c) = codec {
-        c.decode(payloads)
+        c.decode(payloads).await
     } else {
         MessageBatch::new_binary(payloads)
     }
@@ -62,24 +62,24 @@ pub fn apply_codec_to_payloads(
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_apply_codec_to_payload_no_codec() {
+    #[tokio::test]
+    async fn test_apply_codec_to_payload_no_codec() {
         let payload = b"test data";
         let codec: Option<Arc<dyn Codec>> = None;
 
-        let result = apply_codec_to_payload(payload, &codec);
+        let result = apply_codec_to_payload(payload, &codec).await;
         assert!(result.is_ok());
 
         let batch = result.unwrap();
         assert_eq!(batch.len(), 1);
     }
 
-    #[test]
-    fn test_apply_codec_to_payloads_no_codec() {
+    #[tokio::test]
+    async fn test_apply_codec_to_payloads_no_codec() {
         let payloads = vec![b"data1".to_vec(), b"data2".to_vec()];
         let codec: Option<Arc<dyn Codec>> = None;
 
-        let result = apply_codec_to_payloads(payloads, &codec);
+        let result = apply_codec_to_payloads(payloads, &codec).await;
         assert!(result.is_ok());
 
         let batch = result.unwrap();

--- a/crates/arkflow-plugin/src/input/generate.rs
+++ b/crates/arkflow-plugin/src/input/generate.rs
@@ -90,7 +90,7 @@ impl Input for GenerateInput {
 
         // Apply codec if configured
         let mut message_batch =
-            crate::input::codec_helper::apply_codec_to_payloads(msgs, &self.codec)?;
+            crate::input::codec_helper::apply_codec_to_payloads(msgs, &self.codec).await?;
         message_batch.set_input_name(self.input_name.clone());
         Ok((Arc::new(message_batch), Arc::new(NoopAck)))
     }

--- a/crates/arkflow-plugin/src/input/http.rs
+++ b/crates/arkflow-plugin/src/input/http.rs
@@ -118,7 +118,7 @@ impl HttpInput {
 
         // Apply codec if configured
         let msg =
-            match crate::input::codec_helper::apply_codec_to_payload(&json_bytes, &state.codec) {
+            match crate::input::codec_helper::apply_codec_to_payload(&json_bytes, &state.codec).await {
                 Ok(msg) => msg,
                 Err(_) => return StatusCode::BAD_REQUEST,
             };

--- a/crates/arkflow-plugin/src/input/kafka.rs
+++ b/crates/arkflow-plugin/src/input/kafka.rs
@@ -197,7 +197,7 @@ impl Input for KafkaInput {
 
                 // Apply codec if configured
                 let mut msg_batch =
-                    crate::input::codec_helper::apply_codec_to_payload(payload, &self.codec)?;
+                    crate::input::codec_helper::apply_codec_to_payload(payload, &self.codec).await?;
                 msg_batch.set_input_name(self.input_name.clone());
 
                 // Convert to RecordBatch to add metadata

--- a/crates/arkflow-plugin/src/input/memory.rs
+++ b/crates/arkflow-plugin/src/input/memory.rs
@@ -59,7 +59,14 @@ impl MemoryInput {
             for msg_str in messages {
                 // Apply codec if configured
                 let msg_batch = if let Some(c) = &codec {
-                    c.decode(vec![msg_str.as_bytes().to_vec()])?
+                    // Codec decode is async; `new()` is sync (called from `InputBuilder::build`).
+                    // Block-on the runtime to decode initial messages at construction.
+                    // Requires a multi-thread tokio runtime; memory input is a test component
+                    // and this path is only hit when a codec + initial messages are configured.
+                    tokio::task::block_in_place(|| {
+                        tokio::runtime::Handle::current()
+                            .block_on(c.decode(vec![msg_str.as_bytes().to_vec()]))
+                    })?
                 } else {
                     MessageBatch::from_string(msg_str)?
                 };
@@ -84,7 +91,7 @@ impl MemoryInput {
 
     /// Add raw bytes to the memory input (codec will be applied if configured)
     pub async fn push_bytes(&self, data: Vec<u8>) -> Result<(), Error> {
-        let msg_batch = crate::input::codec_helper::apply_codec_to_payload(&data, &self.codec)?;
+        let msg_batch = crate::input::codec_helper::apply_codec_to_payload(&data, &self.codec).await?;
         let mut queue = self.queue.lock().await;
         queue.push_back(msg_batch);
         Ok(())

--- a/crates/arkflow-plugin/src/input/mqtt.rs
+++ b/crates/arkflow-plugin/src/input/mqtt.rs
@@ -200,7 +200,7 @@ impl Input for MqttInput {
                                 let mut msg = crate::input::codec_helper::apply_codec_to_payload(
                                     &payload,
                                     &self.codec,
-                                )?;
+                                ).await?;
                                 msg.set_input_name(self.input_name.clone());
 
                                 Ok((Arc::new(msg), Arc::new(MqttAck {

--- a/crates/arkflow-plugin/src/input/nats.rs
+++ b/crates/arkflow-plugin/src/input/nats.rs
@@ -367,7 +367,7 @@ impl Input for NatsInput {
                                 let mut msg_batch = crate::input::codec_helper::apply_codec_to_payload(
                                     &payload,
                                     &self.codec,
-                                )?;
+                                ).await?;
                                 msg_batch.set_input_name(self.input_name.clone());
 
                                 Ok((Arc::new(msg_batch), Arc::new(NatsAck::Regular)))
@@ -379,7 +379,7 @@ impl Input for NatsInput {
                                 let mut msg_batch = crate::input::codec_helper::apply_codec_to_payload(
                                     &payload,
                                     &self.codec,
-                                )?;
+                                ).await?;
                                 msg_batch.set_input_name(self.input_name.clone());
 
                                 let ack = NatsAck::JetStream {

--- a/crates/arkflow-plugin/src/input/pulsar.rs
+++ b/crates/arkflow-plugin/src/input/pulsar.rs
@@ -227,7 +227,7 @@ impl Input for PulsarInput {
                                 let mut msg_batch = crate::input::codec_helper::apply_codec_to_payload(
                                     &payload,
                                     &self.codec,
-                                )?;
+                                ).await?;
                                 msg_batch.set_input_name(self.input_name.clone());
 
                                 // Get consumer reference for acknowledgment

--- a/crates/arkflow-plugin/src/input/redis.rs
+++ b/crates/arkflow-plugin/src/input/redis.rs
@@ -409,7 +409,7 @@ impl Input for RedisInput {
             Ok(RedisMsg::Message(_channel, payload)) => {
                 // Apply codec if configured
                 let mut msg =
-                    crate::input::codec_helper::apply_codec_to_payload(&payload, &self.codec)
+                    crate::input::codec_helper::apply_codec_to_payload(&payload, &self.codec).await
                         .map_err(|e| {
                             Error::Connection(format!("Failed to create message batch: {}", e))
                         })?;

--- a/crates/arkflow-plugin/src/input/websocket.rs
+++ b/crates/arkflow-plugin/src/input/websocket.rs
@@ -170,7 +170,7 @@ impl Input for WebSocketInput {
                                 let mut msg = crate::input::codec_helper::apply_codec_to_payload(
                                     &payload,
                                     &self.codec,
-                                )?;
+                                ).await?;
                                 msg.set_input_name(self.input_name.clone());
 
                                 Ok((Arc::new(msg), Arc::new(NoopAck)))

--- a/crates/arkflow-plugin/src/output/codec_helper.rs
+++ b/crates/arkflow-plugin/src/output/codec_helper.rs
@@ -27,14 +27,14 @@ use std::sync::Arc;
 /// # Returns
 /// * `Ok(Vec<Bytes>)` - Encoded bytes or binary representation
 /// * `Err(Error)` - If codec application fails
-pub fn apply_codec_encode(
+pub async fn apply_codec_encode(
     msg: &MessageBatchRef,
     codec: &Option<Arc<dyn Codec>>,
 ) -> Result<Vec<Bytes>, Error> {
     if let Some(c) = codec {
         // Clone the MessageBatch for encoding
         let msg_clone = (**msg).clone();
-        c.encode(msg_clone)
+        c.encode(msg_clone).await
     } else {
         // Default: convert to binary
         let binary_data = msg.to_binary(DEFAULT_BINARY_VALUE_FIELD)?;
@@ -48,14 +48,14 @@ mod tests {
     use super::*;
     use arkflow_core::MessageBatch;
 
-    #[test]
-    fn test_apply_codec_encode_no_codec() {
+    #[tokio::test]
+    async fn test_apply_codec_encode_no_codec() {
         // Create a simple message batch
         let batch = MessageBatch::new_binary(vec![b"test data".to_vec()]).unwrap();
         let msg_ref = std::sync::Arc::new(batch);
         let codec: Option<Arc<dyn Codec>> = None;
 
-        let result = apply_codec_encode(&msg_ref, &codec);
+        let result = apply_codec_encode(&msg_ref, &codec).await;
         assert!(result.is_ok());
 
         let bytes = result.unwrap();

--- a/crates/arkflow-plugin/src/output/http.rs
+++ b/crates/arkflow-plugin/src/output/http.rs
@@ -101,7 +101,7 @@ impl Output for HttpOutput {
 
     async fn write(&self, msg: MessageBatchRef) -> Result<(), Error> {
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         if payloads.is_empty() {
             return Ok(());
         }

--- a/crates/arkflow-plugin/src/output/influxdb.rs
+++ b/crates/arkflow-plugin/src/output/influxdb.rs
@@ -443,7 +443,7 @@ impl Output for InfluxDBOutput {
 
         // Apply codec encoding if configured
         let processed_msgs = if let Some(codec) = &self.codec {
-            codec.encode((*msg).clone())?
+            codec.encode((*msg).clone()).await?
         } else {
             // No codec: extract binary data and re-create MessageBatch
             let binary_data = msg.to_binary("")?;

--- a/crates/arkflow-plugin/src/output/kafka.rs
+++ b/crates/arkflow-plugin/src/output/kafka.rs
@@ -186,7 +186,7 @@ impl Output for KafkaOutput {
         })?;
 
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         if payloads.is_empty() {
             return Ok(());
         }

--- a/crates/arkflow-plugin/src/output/kafka.rs
+++ b/crates/arkflow-plugin/src/output/kafka.rs
@@ -76,6 +76,29 @@ struct KafkaOutputConfig {
     acks: Option<String>,
     /// Value type
     value_field: Option<String>,
+    /// Enable exactly-once transactional production (L2). Default false.
+    exactly_once: Option<bool>,
+    /// Transactional id (required when exactly_once is true). Must be stable
+    /// across restarts so the broker can fence prior producer epochs.
+    transactional_id: Option<String>,
+}
+
+/// Map a Kafka transaction error to an `Error`, logging which of rdkafka's
+/// three transactional states it is in. Failures return `Err` so the stream
+/// withholds the ack and replays the whole batch (which re-begins a fresh
+/// transaction); the broker fences zombie producers via the stable
+/// transactional.id on restart.
+fn map_kafka_txn_error(e: KafkaError, ctx: &str) -> Error {
+    if let KafkaError::Transaction(rd) = &e {
+        if rd.is_fatal() {
+            error!("Kafka {} fatal (producer must be discarded): {:?}", ctx, e);
+        } else if rd.txn_requires_abort() {
+            error!("Kafka {} requires abort (will replay): {:?}", ctx, e);
+        } else if rd.is_retriable() {
+            error!("Kafka {} retriable (will replay): {:?}", ctx, e);
+        }
+    }
+    Error::Connection(format!("Kafka {} failed: {}", ctx, e))
 }
 
 /// Kafka output component
@@ -165,10 +188,35 @@ impl Output for KafkaOutput {
             client_config.set("acks", acks);
         }
 
+        let exactly_once = self.config.exactly_once.unwrap_or(false);
+
+        // Configure the transactional producer when exactly_once is enabled.
+        // Idempotence is implied by transactional.id but set explicitly.
+        if exactly_once {
+            client_config.set(
+                "transactional.id",
+                self.config.transactional_id.as_ref().expect(
+                    "transactional_id presence is validated by the builder when exactly_once is on",
+                ),
+            );
+            client_config.set("enable.idempotence", "true");
+        }
+
         // Create a producer
-        let producer = client_config
+        let producer: FutureProducer = client_config
             .create()
             .map_err(|e| Error::Connection(format!("A Kafka producer cannot be created: {}", e)))?;
+
+        // Initialize transactions once (blocking broker round-trip).
+        if exactly_once {
+            let p = producer.clone();
+            tokio::task::spawn_blocking(move || {
+                p.init_transactions(Timeout::After(Duration::from_secs(60)))
+            })
+            .await
+            .map_err(|e| Error::Connection(format!("init_transactions task join failed: {}", e)))?
+            .map_err(|e| Error::Connection(format!("Kafka init_transactions failed: {}", e)))?;
+        }
 
         // Save the producer instance
         let producer_arc = self.inner_kafka_output.producer.clone();
@@ -242,6 +290,24 @@ impl Output for KafkaOutput {
         Ok(())
     }
 
+    async fn write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error> {
+        if !self.config.exactly_once.unwrap_or(false) {
+            // Non-transactional path: default per-message behavior
+            // (continue-on-error), inlined to avoid a Default-trait dance.
+            let mut err = None;
+            for msg in msgs {
+                if let Err(e) = self.write(msg.clone()).await {
+                    err = Some(e);
+                }
+            }
+            return match err {
+                Some(e) => Err(e),
+                None => Ok(()),
+            };
+        }
+        self.write_batch_transactional(msgs).await
+    }
+
     async fn close(&self) -> Result<(), Error> {
         self.cancellation_token.cancel();
         // Get the producer and close
@@ -274,6 +340,115 @@ impl Output for KafkaOutput {
     }
 }
 impl KafkaOutput {
+    /// Transactional write: begin → send all → commit. On any failure, abort
+    /// (best-effort) and return Err so the stream withholds the ack and
+    /// replays the whole batch — which re-begins a fresh transaction. Zombie
+    /// producers from a crashed run are fenced by the broker via the stable
+    /// transactional.id on restart.
+    async fn write_batch_transactional(
+        &self,
+        msgs: &[MessageBatchRef],
+    ) -> Result<(), Error> {
+        let producer_guard = self.inner_kafka_output.producer.read().await;
+        let producer = match producer_guard.as_ref() {
+            Some(p) => p,
+            None => {
+                return Err(Error::Connection(
+                    "The Kafka producer is not initialized".to_string(),
+                ));
+            }
+        };
+
+        if let Err(e) = producer.begin_transaction() {
+            return Err(map_kafka_txn_error(e, "begin_transaction"));
+        }
+
+        let mut failed: Option<Error> = None;
+        for msg in msgs {
+            if let Err(e) = self.send_in_transaction(producer, msg.clone()).await {
+                error!("Kafka transactional send failed: {}", e);
+                failed = Some(e);
+                break;
+            }
+        }
+
+        if let Some(e) = failed {
+            // Best-effort abort; the broker fences zombies on restart anyway.
+            let p = producer.clone();
+            drop(producer_guard);
+            if let Err(ab) = tokio::task::spawn_blocking(move || {
+                p.abort_transaction(Timeout::After(Duration::from_secs(30)))
+            })
+            .await
+            {
+                error!("Kafka abort_transaction task join failed: {}", ab);
+            }
+            return Err(e);
+        }
+
+        // Commit (blocking broker round-trip → spawn_blocking).
+        let p = producer.clone();
+        drop(producer_guard);
+        match tokio::task::spawn_blocking(move || {
+            p.commit_transaction(Timeout::After(Duration::from_secs(30)))
+        })
+        .await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(map_kafka_txn_error(e, "commit_transaction")),
+            Err(e) => Err(Error::Connection(format!(
+                "commit_transaction task join failed: {}",
+                e
+            ))),
+        }
+    }
+
+    /// Send one message's records into the current transaction. Does not
+    /// collect delivery futures — commit_transaction flushes the queue.
+    async fn send_in_transaction(
+        &self,
+        producer: &FutureProducer,
+        msg: MessageBatchRef,
+    ) -> Result<(), Error> {
+        let payloads =
+            crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
+        if payloads.is_empty() {
+            return Ok(());
+        }
+        let topic = self.get_topic(&msg).await?;
+        let key = self.get_key(&msg).await?;
+
+        for (i, x) in payloads.into_iter().enumerate() {
+            let mut record = match &topic {
+                EvaluateResult::Scalar(s) => FutureRecord::to(s).payload(x.as_slice()),
+                EvaluateResult::Vec(v) => FutureRecord::to(&*v[i]).payload(x.as_slice()),
+            };
+            match &key {
+                Some(EvaluateResult::Scalar(s)) => record = record.key(s),
+                Some(EvaluateResult::Vec(v)) if i < v.len() => {
+                    record = record.key(&v[i]);
+                }
+                _ => {}
+            }
+
+            loop {
+                match producer.send_result(record) {
+                    Ok(_future) => break,
+                    Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), f)) => {
+                        record = f;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err((e, _)) => {
+                        return Err(Error::Connection(format!(
+                            "Failed to write to Kafka transaction: {e}"
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn get_topic(&self, msg: &MessageBatch) -> Result<EvaluateResult<String>, Error> {
         self.config.topic.evaluate_expr(msg).await
     }
@@ -304,6 +479,22 @@ impl OutputBuilder for KafkaOutputBuilder {
 
         // Parse the configuration
         let config: KafkaOutputConfig = serde_json::from_value(config.clone().unwrap())?;
+
+        // D5: exactly_once requires a non-empty transactional_id (spec:
+        // "Explicit stable transactional identity").
+        if config.exactly_once.unwrap_or(false) {
+            match &config.transactional_id {
+                Some(id) if !id.trim().is_empty() => {}
+                _ => {
+                    return Err(Error::Config(
+                        "Kafka output: transactional_id is required and must be \
+                         non-empty when exactly_once is true"
+                            .into(),
+                    ));
+                }
+            }
+        }
+
         Ok(Arc::new(KafkaOutput::new(config, codec)?))
     }
 }
@@ -323,7 +514,9 @@ pub fn init() -> Result<(), Error> {
                 "client_id": {"type": "string", "description": "Optional client identifier."},
                 "compression": {"type": "string", "enum": ["none", "gzip", "snappy", "lz4", "zstd"], "description": "Compression algorithm."},
                 "acks": {"type": "string", "enum": ["0", "1", "all"], "description": "Acknowledgment level."},
-                "value_field": {"type": "string", "description": "Record field used as the message payload."}
+                "value_field": {"type": "string", "description": "Record field used as the message payload."},
+                "exactly_once": {"type": "boolean", "default": false, "description": "Enable exactly-once transactional production (L2)."},
+                "transactional_id": {"type": "string", "description": "Transactional id (required when exactly_once is true); must be stable across restarts for zombie fencing."}
             },
             "required": ["brokers", "topic"]
         }),
@@ -331,4 +524,57 @@ pub fn init() -> Result<(), Error> {
         "brokers": ["localhost:9092"],
         "topic": "events"
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    fn resource() -> Resource {
+        Resource {
+            temporary: HashMap::new(),
+            input_names: RefCell::new(vec![]),
+        }
+    }
+
+    /// Spec "Explicit stable transactional identity": the builder rejects
+    /// `exactly_once: true` without a non-empty `transactional_id`.
+    #[test]
+    fn rejects_exactly_once_without_transactional_id() {
+        let config = serde_json::json!({
+            "brokers": ["localhost:9092"],
+            "topic": {"type": "value", "value": "t"},
+            "exactly_once": true
+        });
+        let err = match KafkaOutputBuilder
+            .build(None, &Some(config), None, &resource())
+        {
+            Ok(_) => panic!(
+                "expected build to fail when exactly_once is set without a transactional_id"
+            ),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("transactional_id"),
+            "expected transactional_id in error, got: {msg}"
+        );
+    }
+
+    /// `exactly_once: true` with a `transactional_id` builds successfully
+    /// (the producer itself is only created at `connect` time).
+    #[tokio::test]
+    async fn accepts_exactly_once_with_transactional_id() {
+        let config = serde_json::json!({
+            "brokers": ["localhost:9092"],
+            "topic": {"type": "value", "value": "t"},
+            "exactly_once": true,
+            "transactional_id": "my-tx-id"
+        });
+        let _output = KafkaOutputBuilder
+            .build(None, &Some(config), None, &resource())
+            .expect("build should succeed; producer is created at connect");
+    }
 }

--- a/crates/arkflow-plugin/src/output/mqtt.rs
+++ b/crates/arkflow-plugin/src/output/mqtt.rs
@@ -148,7 +148,7 @@ impl<T: MqttClient> Output for MqttOutput<T> {
             .ok_or_else(|| Error::Connection("The MQTT client is not initialized".to_string()))?;
 
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         if payloads.is_empty() {
             return Ok(());
         }

--- a/crates/arkflow-plugin/src/output/nats.rs
+++ b/crates/arkflow-plugin/src/output/nats.rs
@@ -138,7 +138,7 @@ impl Output for NatsOutput {
             .ok_or_else(|| Error::Connection("NATS client not connected".to_string()))?;
 
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         if payloads.is_empty() {
             return Ok(());
         }

--- a/crates/arkflow-plugin/src/output/pulsar.rs
+++ b/crates/arkflow-plugin/src/output/pulsar.rs
@@ -111,7 +111,7 @@ impl Output for PulsarOutput {
             .ok_or_else(|| Error::Connection("Pulsar client not connected".to_string()))?;
 
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         if payloads.is_empty() {
             return Ok(());
         }

--- a/crates/arkflow-plugin/src/output/redis.rs
+++ b/crates/arkflow-plugin/src/output/redis.rs
@@ -90,7 +90,7 @@ impl Output for RedisOutput {
 
     async fn write(&self, msg: MessageBatchRef) -> Result<(), Error> {
         // Apply codec encoding if configured
-        let data = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let data = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
         let client_lock = self.client.lock().await;
         let Some(cli) = client_lock.as_ref() else {
             return Err(Error::Process(

--- a/crates/arkflow-plugin/src/output/sql.rs
+++ b/crates/arkflow-plugin/src/output/sql.rs
@@ -266,7 +266,7 @@ impl Output for SqlOutput {
 
         // Apply codec encoding if configured, otherwise use the message as-is
         let processed_msg = if let Some(codec) = &self.codec {
-            let encoded = codec.encode((*msg).clone())?;
+            let encoded = codec.encode((*msg).clone()).await?;
             // Convert encoded bytes back to MessageBatch for SQL insertion
             // This is a simplified approach - in practice, you might need more sophisticated handling
             MessageBatch::new_binary(encoded)?

--- a/crates/arkflow-plugin/src/output/stdout.rs
+++ b/crates/arkflow-plugin/src/output/stdout.rs
@@ -68,7 +68,7 @@ where
 
     async fn write(&self, msg: MessageBatchRef) -> Result<(), Error> {
         // Apply codec encoding if configured
-        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec)?;
+        let payloads = crate::output::codec_helper::apply_codec_encode(&msg, &self.codec).await?;
 
         // Write each payload to stdout
         let mut writer_std = self.writer.lock().await;

--- a/crates/arkflow-plugin/src/temporary/redis.rs
+++ b/crates/arkflow-plugin/src/temporary/redis.rs
@@ -116,7 +116,7 @@ impl Temporary for RedisTemporary {
             .flatten()
             .map(|s| s.as_bytes().to_vec())
             .collect::<Vec<_>>();
-        let result = self.codec.decode(data)?;
+        let result = self.codec.decode(data).await?;
         Ok(Some(result))
     }
 

--- a/crates/arkflow-plugin/tests/kafka_eos.rs
+++ b/crates/arkflow-plugin/tests/kafka_eos.rs
@@ -1,0 +1,374 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+//! End-to-end exactly-once integration tests against a real Kafka broker.
+//!
+//! Spins up a single-node Confluent Kafka (KRaft) broker via `testcontainers`,
+//! then drives `KafkaOutput` (exactly_once + transactional_id) through the
+//! public `Output::write_batch` contract and verifies the transactional
+//! semantics with a `read_committed` rdkafka consumer.
+//!
+//! Broker choice: the spec/design name redpanda as the example broker. These
+//! tests use `confluentinc/cp-kafka` because (a) it is the Kafka reference
+//! implementation for transactions, (b) it is reliably pullable in CI, and
+//! (c) redpanda is wire-compatible — the EOS semantics under test (atomic
+//! commit, zombie fencing, the post-commit duplicate window) are identical.
+//! `tasks.md` 3.1 explicitly permits a broker fallback.
+//!
+//! These tests are NOT `#[ignore]` — testcontainers manages the broker
+//! lifecycle, so `cargo test --test kafka_eos` works wherever Docker is
+//! available. All cases share one broker (fixed host port 9092) and run
+//! serially; each isolates by unique topic / transactional id / group.
+
+use arkflow_core::output::{Output, OutputConfig};
+use arkflow_core::{MessageBatch, MessageBatchRef, Resource};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use testcontainers::core::IntoContainerPort;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+use tokio::sync::OnceCell;
+
+/// KRaft cluster id: must be a base64-encoded UUID (16 bytes → 22 chars,
+/// no padding). An arbitrary UUID string is rejected by cp-kafka and the
+/// container exits(1) before opening the Kafka port.
+const CLUSTER_ID: &str = "1RlfgIc1TZWvdfLySKufPw";
+/// Fixed host port so the broker's advertised listener matches where clients
+/// connect (KRaft `KAFKA_ADVERTISED_LISTENERS` is baked in at startup, so the
+/// host port cannot be dynamic).
+const KAFKA_HOST_PORT: u16 = 9092;
+
+/// Shared broker — started once, reused by every (serial) test to avoid the
+/// fixed-port release race between back-to-back containers.
+static BROKER: OnceCell<ContainerAsync<GenericImage>> = OnceCell::const_new();
+
+async fn broker() {
+    BROKER
+        .get_or_init(start_broker)
+        .await;
+}
+
+/// Register all output builders exactly once.
+static INIT: std::sync::Once = std::sync::Once::new();
+fn ensure_init() {
+    INIT.call_once(|| {
+        arkflow_plugin::output::init().expect("plugin output init");
+    });
+}
+
+fn resource() -> Resource {
+    Resource {
+        temporary: HashMap::new(),
+        input_names: std::cell::RefCell::new(vec![]),
+    }
+}
+
+/// A single-row binary `MessageBatch` whose payload is the given bytes. The
+/// column is `__value__` (`DEFAULT_BINARY_VALUE_FIELD`), so the default
+/// no-codec encode path emits exactly one Kafka message per batch.
+fn binary_batch(payload: &[u8]) -> MessageBatchRef {
+    Arc::new(MessageBatch::new_binary(vec![payload.to_vec()]).expect("binary batch"))
+}
+
+/// Start a single-node KRaft Kafka broker on fixed host port 9092.
+async fn start_broker() -> ContainerAsync<GenericImage> {
+    let image = GenericImage::new("confluentinc/cp-kafka", "7.5.0")
+        .with_env_var("CLUSTER_ID", CLUSTER_ID)
+        .with_env_var("KAFKA_PROCESS_ROLES", "broker,controller")
+        .with_env_var("KAFKA_NODE_ID", "1")
+        .with_env_var("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@localhost:29093")
+        .with_env_var(
+            "KAFKA_LISTENERS",
+            "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093",
+        )
+        .with_env_var("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://localhost:9092")
+        .with_env_var(
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+            "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+        )
+        .with_env_var("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
+        .with_env_var("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+        .with_env_var("KAFKA_LOG_DIRS", "/tmp/kraft-combined")
+        .with_env_var("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+        .with_env_var("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+        .with_env_var("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+        .with_env_var("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+        .with_env_var("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+        .with_mapped_port(KAFKA_HOST_PORT, KAFKA_HOST_PORT.tcp())
+        .with_startup_timeout(Duration::from_secs(180));
+    let container = image.start().await.expect("broker container start");
+    wait_for_broker("localhost:9092").await;
+    container
+}
+
+/// Poll broker metadata until a Kafka client can connect (or ~90s elapse).
+/// cp-kafka's stdout "ready" log line varies across versions, so a metadata
+/// probe is the source of truth.
+async fn wait_for_broker(brokers: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(90);
+    loop {
+        let ok = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("request.timeout.ms", "3000")
+            .create::<rdkafka::producer::BaseProducer>()
+            .and_then(|p| p.client().fetch_metadata(None, Duration::from_secs(3)))
+            .is_ok();
+        if ok {
+            return;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("Kafka broker not ready (metadata probe failed) within 90s");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Build a `KafkaOutput` via the public registry path. When `exactly_once` is
+/// set, `tx_id` must be provided and is used as the stable transactional id.
+async fn build_output(topic: &str, exactly_once: bool, tx_id: Option<&str>) -> Arc<dyn Output> {
+    ensure_init();
+    let mut cfg = serde_json::json!({
+        "brokers": ["localhost:9092"],
+        "topic": {"type": "value", "value": topic},
+    });
+    if exactly_once {
+        cfg["exactly_once"] = serde_json::json!(true);
+        cfg["transactional_id"] = serde_json::json!(tx_id.expect("tx id required"));
+    }
+    let out = OutputConfig {
+        output_type: "kafka".into(),
+        name: None,
+        codec: None,
+        config: Some(cfg),
+    }
+    .build(&resource())
+    .expect("build kafka output");
+    out.connect().await.expect("kafka output connect");
+    out
+}
+
+/// A raw transactional producer (for the fencing test, which must control
+/// transaction boundaries directly rather than through `write_batch`).
+fn txn_producer(tx_id: &str) -> FutureProducer {
+    ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .set("transactional.id", tx_id)
+        .set("enable.idempotence", "true")
+        .set("acks", "all")
+        .set("message.timeout.ms", "15000")
+        .create()
+        .expect("txn producer create")
+}
+
+/// `init_transactions` is a blocking broker round-trip — run it off the async
+/// worker.
+async fn txn_init(producer: FutureProducer) -> FutureProducer {
+    let p = producer.clone();
+    tokio::task::spawn_blocking(move || p.init_transactions(Duration::from_secs(30)))
+        .await
+        .expect("init_transactions join")
+        .expect("init_transactions");
+    producer
+}
+
+/// `begin_transaction` (blocking).
+async fn txn_begin(producer: &FutureProducer) {
+    let p = producer.clone();
+    tokio::task::spawn_blocking(move || p.begin_transaction())
+        .await
+        .expect("begin join")
+        .expect("begin_transaction");
+}
+
+/// `commit_transaction` (blocking).
+async fn txn_commit(producer: &FutureProducer) {
+    let p = producer.clone();
+    tokio::task::spawn_blocking(move || p.commit_transaction(Duration::from_secs(30)))
+        .await
+        .expect("commit join")
+        .expect("commit_transaction");
+}
+
+/// `flush` (blocking) — ensure queued records reach the broker.
+async fn txn_flush(producer: &FutureProducer) {
+    let p = producer.clone();
+    tokio::task::spawn_blocking(move || p.flush(Duration::from_secs(15)))
+        .await
+        .expect("flush join")
+        .expect("flush");
+}
+
+/// A `read_committed` consumer (the lens through which EOS is observed).
+fn read_committed_consumer(group: &str) -> StreamConsumer {
+    ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .set("group.id", group)
+        .set("isolation.level", "read_committed")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .set("session.timeout.ms", "10000")
+        .create()
+        .expect("consumer create")
+}
+
+/// Subscribe, let the group rebalance, then count non-empty messages within
+/// `timeout`.
+async fn subscribe_and_drain(consumer: &StreamConsumer, topic: &str, timeout: Duration) -> usize {
+    consumer.subscribe(&[topic]).expect("subscribe");
+    // Allow the consumer group to rebalance and acquire a partition
+    // assignment before draining.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let mut n = 0;
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), consumer.recv()).await {
+            Ok(Ok(m)) => {
+                if m.payload().is_some() {
+                    n += 1;
+                }
+            }
+            Ok(Err(_)) => {} // transient (mid-rebalance); keep going
+            Err(_) => {}    // per-poll timeout; keep going until overall deadline
+        }
+    }
+    n
+}
+
+/// Smoke test: the broker starts, a non-transactional `write_batch` produces,
+/// and a `read_committed` consumer observes the messages. Validates the whole
+/// fixture before the transactional cases lean on it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn smoke_broker_and_roundtrip() {
+    broker().await;
+    let topic = format!("eos-smoke-{}", std::process::id());
+    let output = build_output(&topic, false, None).await;
+    output
+        .write_batch(&[binary_batch(b"one"), binary_batch(b"two")])
+        .await
+        .expect("non-txn write_batch");
+    output.close().await.expect("output close");
+
+    let consumer = read_committed_consumer(&topic);
+    let received = subscribe_and_drain(&consumer, &topic, Duration::from_secs(20)).await;
+    assert!(
+        received >= 1,
+        "smoke: expected at least one message, got {received}"
+    );
+}
+
+/// 3.2 — One `write_batch` with N messages commits as one atomic unit: a
+/// `read_committed` consumer observes all of them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn atomic_commit_observes_whole_batch() {
+    broker().await;
+    let topic = format!("eos-atomic-{}", std::process::id());
+    let tx_id = format!("atomic-tx-{}", std::process::id());
+
+    let output = build_output(&topic, true, Some(&tx_id)).await;
+    output
+        .write_batch(&[
+            binary_batch(b"a"),
+            binary_batch(b"b"),
+            binary_batch(b"c"),
+        ])
+        .await
+        .expect("transactional write_batch");
+    output.close().await.expect("output close");
+
+    let consumer = read_committed_consumer(&format!("{tx_id}-c"));
+    let received = subscribe_and_drain(&consumer, &topic, Duration::from_secs(20)).await;
+    assert_eq!(
+        received, 3,
+        "atomic commit: read_committed consumer must see all 3 messages, got {received}"
+    );
+}
+
+/// 3.3 — Zombie fencing across a simulated restart. Producer 1 begins a
+/// transaction and sends "zombie", then "crashes" (dropped without
+/// committing). Producer 2 reuses the same `transactional.id`; its
+/// `init_transactions` bumps the broker epoch and fences producer 1's
+/// in-flight (uncommitted) transaction. Producer 2 then commits "winner". A
+/// `read_committed` consumer sees only "winner" — the fenced "zombie" write
+/// is never visible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn zombie_fenced_across_restart() {
+    broker().await;
+    let topic = format!("eos-fence-{}", std::process::id());
+    let tx_id = format!("fence-tx-{}", std::process::id());
+
+    // Producer 1: begin + send + flush, then "crash" (drop, no commit).
+    let p1 = txn_init(txn_producer(&tx_id)).await;
+    txn_begin(&p1).await;
+    p1.send_result(FutureRecord::<(), _>::to(&topic).payload(b"zombie"))
+        .expect("zombie send_result");
+    txn_flush(&p1).await;
+    drop(p1); // crash
+
+    // Producer 2 (same tx_id) fences producer 1, then commits "winner".
+    let p2 = txn_init(txn_producer(&tx_id)).await;
+    txn_begin(&p2).await;
+    p2.send_result(FutureRecord::<(), _>::to(&topic).payload(b"winner"))
+        .expect("winner send_result");
+    txn_commit(&p2).await;
+    txn_flush(&p2).await;
+
+    let consumer = read_committed_consumer(&format!("{tx_id}-c"));
+    let received = subscribe_and_drain(&consumer, &topic, Duration::from_secs(20)).await;
+    assert_eq!(
+        received, 1,
+        "fencing: only producer 2's committed message should be visible (zombie fenced), got {received}"
+    );
+}
+
+/// 3.4 — Honest L2 boundary. Producer commits a batch, then the process
+/// "crashes" before the source offset is committed; on recovery the same
+/// `transactional.id` replays the identical batch. Both writes are visible
+/// to a `read_committed` consumer — i.e. L2 does NOT eliminate this
+/// duplicate window (downstream idempotency / future L3 is required).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn post_commit_crash_duplicates() {
+    broker().await;
+    let topic = format!("eos-dup-{}", std::process::id());
+    let tx_id = format!("dup-tx-{}", std::process::id());
+
+    // First commit, then "crash" before the source offset commits.
+    let out1 = build_output(&topic, true, Some(&tx_id)).await;
+    out1.write_batch(&[binary_batch(b"x")])
+        .await
+        .expect("first commit");
+    drop(out1); // crash — source offset never committed
+
+    // Recovery: same tx_id, replay the identical batch.
+    let out2 = build_output(&topic, true, Some(&tx_id)).await;
+    out2.write_batch(&[binary_batch(b"x")])
+        .await
+        .expect("replay commit");
+    out2.close().await.expect("output close");
+
+    let consumer = read_committed_consumer(&format!("{tx_id}-c"));
+    let received = subscribe_and_drain(&consumer, &topic, Duration::from_secs(20)).await;
+    assert_eq!(
+        received, 2,
+        "L2 honest boundary: post-commit crash must duplicate (both writes visible), got {received}"
+    );
+}

--- a/docs/docs/components/5-codecs/_category_.json
+++ b/docs/docs/components/5-codecs/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Codecs",
+  "link": {
+    "type": "generated-index",
+    "description": "Codec components handle serialization/deserialization between byte payloads and columnar Arrow batches at the input/output boundary."
+  }
+}

--- a/docs/docs/components/5-codecs/debezium.md
+++ b/docs/docs/components/5-codecs/debezium.md
@@ -1,0 +1,60 @@
+# debezium_json
+
+`debezium_json` is a **codec** that decodes Debezium CDC (Change Data Capture) Envelope JSON into a columnar Arrow batch. Attach it to a Kafka input that consumes a topic written by Debezium to turn database change events into queryable rows.
+
+## When to use
+
+- Real-time database change synchronization from MySQL / PostgreSQL / MongoDB / SQLServer / ... via Debezium.
+- CDC pipelines that need `op`-aware routing (`c` / `u` / `d` / `r`) in downstream SQL.
+
+## Deployment shape
+
+Debezium writes change events to Kafka; ArkFlow consumes them with this codec:
+
+```
+Database → Debezium (Kafka Connect / Debezium Server) → Kafka topic → ArkFlow (kafka input + debezium_json codec)
+```
+
+## Configuration
+
+The codec takes no options today:
+
+```yaml
+input:
+  type: kafka
+  brokers:
+    - localhost:9092
+  topics:
+    - shop.users
+  consumer_group: arkflow-cdc
+  codec:
+    type: debezium_json
+```
+
+## Output schema
+
+Each Debezium Envelope `{ before, after, op, source, ts_ms }` is flattened into a row:
+
+| Column | Source | Notes |
+| --- | --- | --- |
+| `<business fields>` | `after` (or `before` for `op="d"`) | promoted to top-level columns |
+| `op` | `op` | `c` / `u` / `d` / `r` |
+| `ts_ms` | `ts_ms` | change timestamp |
+| `source_db`, `source_table` | `source.db`, `source.table` | scalar top-level columns |
+| `before` | full `before` object | JSON text column (use SQL JSON functions to inspect) |
+| `source` | full `source` object | JSON text column |
+
+`before` / `source` are kept as JSON text (rather than nested structs) so that a `null`-vs-object mix within a batch (e.g. `before` is null on inserts but an object on updates) decodes uniformly.
+
+## Delivery semantics
+
+CDC offset is **not** managed by this codec — it is the Kafka input's ack-gated offset (see `input-durability`), providing at-least-once. Make downstream sinks idempotent (end-to-end exactly-once is tracked as a separate change).
+
+## Example
+
+See `examples/cdc_debezium.yaml`.
+
+## Non-goals
+
+- MySQL binlog / PostgreSQL logical replication **direct** connection (future independent input).
+- Debezium Avro / Protobuf formats (JSON only for now; Avro depends on Schema Registry).

--- a/docs/docs/components/5-codecs/schema-registry.md
+++ b/docs/docs/components/5-codecs/schema-registry.md
@@ -1,0 +1,61 @@
+# schema_registry
+
+`schema_registry` is a **codec** that decodes Confluent wire-format Protobuf messages by resolving the schema id from a Schema Registry at runtime. It supports schema evolution: each schema version (id) is fetched once and cached, so multiple versions can coexist in the same stream.
+
+## When to use
+
+- Consuming Protobuf messages produced by Confluent serializers (Kafka ecosystem standard wire format).
+- CDC / pipeline scenarios where the source schema evolves and producers register new versions to a Schema Registry.
+
+## Wire format
+
+```
+[0x00 magic][4-byte big-endian schema id][Protobuf payload]
+```
+
+The codec validates the magic byte and strips the id + payload; the id is resolved to a Protobuf schema via the registry.
+
+## Configuration
+
+```yaml
+input:
+  type: kafka
+  brokers:
+    - localhost:9092
+  topics:
+    - test-topic
+  consumer_group: arkflow-sr
+  codec:
+    type: schema_registry
+    registry_url: http://localhost:8081
+    message_type: com.example.User
+    auth:                       # optional
+      type: basic               # or bearer
+      username: ${SR_USER}
+      password: ${SR_PASS}
+```
+
+| Field | Description |
+| --- | --- |
+| `registry_url` | Confluent Schema Registry base URL |
+| `message_type` | Fully-qualified Protobuf message type |
+| `auth` | Optional `basic` (username/password) or `bearer` (token) |
+
+## How it works
+
+1. Parse the Confluent wire format (magic + id + payload).
+2. Resolve `id` to a Protobuf schema (`GET {registry}/schemas/ids/{id}`), cached per id.
+3. Build the `MessageDescriptor` and decode the payload into a columnar Arrow batch.
+
+The schema fetch is pluggable via a `SchemaResolver` trait (`RestSchemaResolver` for production, in-memory for tests), so the wire-format / caching / multi-version logic is unit-testable without a live registry.
+
+## Non-goals
+
+- Avro / JSON Schema types (Protobuf only for now).
+- Writing/registering schemas (read-only consumer).
+- Explicit BACKWARD/FORWARD compatibility checking (enforced by the registry).
+- Protobuf schema references (imports) — single-file schemas only.
+
+## Example
+
+See `examples/schema_registry.yaml`.

--- a/examples/cdc_debezium.yaml
+++ b/examples/cdc_debezium.yaml
@@ -1,0 +1,46 @@
+## CDC via Debezium (Kafka → ArkFlow)
+#
+# Consumes a Kafka topic written by Debezium (MySQL/PostgreSQL/MongoDB/...),
+# decodes each Debezium Envelope into a columnar batch with `debezium_json` codec,
+# then routes by operation type in SQL.
+#
+# CDC offset is the Kafka input's ack-gated offset (at-least-once).
+
+logging:
+  level: info
+
+streams:
+  - input:
+      type: kafka
+      brokers:
+        - localhost:9092
+      topics:
+        - shop.users
+      consumer_group: arkflow-cdc
+      client_id: arkflow-cdc
+      start_from_latest: true
+      # Decode Debezium Envelope JSON into a columnar Arrow batch.
+      # Produces: business columns (from `after`, or `before` on delete),
+      # plus `op`, `ts_ms`, `source_db`, `source_table`, `before`, `source`.
+      codec:
+        type: debezium_json
+
+    pipeline:
+      thread_num: 4
+      processors:
+        - type: sql
+          query: |
+            SELECT
+              op,
+              id,
+              name,
+              source_db,
+              source_table,
+              ts_ms
+            FROM flow
+            WHERE op IN ('c', 'u')
+
+    output:
+      type: stdout
+    error_output:
+      type: stdout

--- a/examples/eos-kafka.yaml
+++ b/examples/eos-kafka.yaml
@@ -1,0 +1,53 @@
+# End-to-end exactly-once (effectively-once) example: Kafka → Kafka.
+#
+# The Kafka output is configured for transactional production (L2):
+#   exactly_once: true + transactional_id
+# All messages within one ack range are committed in a single Kafka transaction,
+# so a read_committed downstream consumer observes them atomically (all or none).
+# On any failure the batch is not acknowledged, the WAL cursor does not advance,
+# and the range is replayed (which re-begins a fresh transaction).
+#
+# transactional_id MUST be stable across restarts: on restart the broker fences
+# the prior producer epoch and aborts its in-flight (zombie) transaction.
+#
+# Honest L2 boundary: a crash AFTER the producer commits but BEFORE the source
+# offset auto-commits can still duplicate (window bounded by the auto-commit
+# interval). A downstream dedup key is recommended for duplicate-intolerant
+# consumers; true end-to-end EOS (L3, send_offsets_to_transaction) is future work.
+#
+# `durability:` persists input messages to a WAL so a crash between read and
+# output does not lose data.
+
+logging:
+  level: info
+
+streams:
+  - input:
+      type: kafka
+      brokers:
+        - localhost:9092
+      topics:
+        - orders
+      consumer_group: arkflow-eos
+      start_from_latest: true
+
+    durability:
+      enabled: true
+      path: "./data/wal-eos"
+      sync: group_commit
+
+    pipeline:
+      thread_num: 4
+      processors:
+        - type: json_to_arrow
+        - type: arrow_to_json
+
+    output:
+      type: kafka
+      brokers:
+        - localhost:9092
+      topic:
+        type: value
+        value: orders-copy
+      exactly_once: true
+      transactional_id: arkflow-orders-copy-0   # stable across restarts; unique per producer

--- a/examples/schema_registry.yaml
+++ b/examples/schema_registry.yaml
@@ -1,0 +1,39 @@
+## Schema Registry (Confluent wire-format Protobuf)
+#
+# Consumes a Kafka topic whose messages are encoded in Confluent wire format
+# (0x00 magic + 4-byte schema id + Protobuf payload), and decodes each message
+# by resolving its schema id from a Confluent Schema Registry.
+
+logging:
+  level: info
+
+streams:
+  - input:
+      type: kafka
+      brokers:
+        - localhost:9092
+      topics:
+        - test-topic
+      consumer_group: arkflow-sr
+      client_id: arkflow-sr
+      start_from_latest: true
+      codec:
+        type: schema_registry
+        registry_url: http://localhost:8081
+        message_type: com.example.User
+        # Optional authentication:
+        # auth:
+        #   type: basic            # or bearer
+        #   username: ${SR_USER}
+        #   password: ${SR_PASS}
+
+    pipeline:
+      thread_num: 4
+      processors:
+        - type: sql
+          query: "SELECT * FROM flow"
+
+    output:
+      type: stdout
+    error_output:
+      type: stdout

--- a/openspec/PLANNING.md
+++ b/openspec/PLANNING.md
@@ -1,0 +1,194 @@
+# ArkFlow 战略规划与方向② Roadmap
+
+> 沉淀于 2026-07-31 的代码库探索。目的：**避免重复探索**——下次会话读本文件即可恢复全部战略上下文，不必重新调研现状。
+> 维护规则：方向或现状发生变化时更新本文档；具体 change 落地后由 OpenSpec `changes/` 与归档后的 `specs/` 承载细节，本文只保留总纲。
+
+---
+
+## 一、现状画像（探索结论，2026-07-31）
+
+版本 `0.5.0`，Rust 1.97，DataFusion 54.1。单二进制、配置式（YAML）、插件化的流处理引擎。
+
+### 1.1 真实强项
+
+| 维度 | 现状 | 证据 |
+| --- | --- | --- |
+| 插件覆盖 | 14 input / 12 output / 6 processor / 6 buffer / 2 codec | `crates/arkflow-plugin/src/{input,output,processor,buffer}/` |
+| 列式数据模型 | Apache Arrow `RecordBatch`（`MessageBatch`），区别于 Vector/Benthos 的行式 JSON | `crates/arkflow-core/src/message_batch_tests.rs`、CLAUDE.md「Data Model」 |
+| SQL 处理 | DataFusion 54，支持聚合/窗口/Join/UDF/临时表 | `crates/arkflow-plugin/src/processor/sql.rs`、`sql/` |
+| Input 级 WAL | at-least-once、ack-gated cursor、crash recovery、S3 后端、节点隔离、segment reclaim、checksum 容错 | `openspec/specs/input-durability/`、`s3-wal-pipeline/`、`wal-manifest-write-coordination/`；`crates/arkflow-plugin/src/wal/` |
+| 脚本能力 | Python UDF（PyO3）+ VRL 双脚本 | `processor/python.rs`、`processor/vrl.rs` |
+| 外部认可 | CNCF Landscape 入选；`components list/show/schema` 命令支撑 IDE 自动补全 | README.md:28；commit `5c398b1` |
+
+### 1.2 真实缺口（机会所在）
+
+1. **AI/ML 完全空缺**。README 主打「无缝集成 AI 能力、加载执行机器学习模型、推理、异常检测、复杂事件处理」（`README.md:16-19`、`README_zh.md:16-17,31`），但：
+   - `Cargo.toml` 无任何 ML 依赖（candle/ort/tract/tch 全无）
+   - `git log` 全量搜索 ai/inference/onnx/tensor/anomaly **零命中**（历史从未实现）
+   - processor 仅 6 种：`batch/json/protobuf/python/sql/vrl`，无原生 AI processor
+   - → **宣传与实现脱节最严重处 = 最大差异化机会**
+2. **单节点、无分布式**。无 cluster/consensus/raft 依赖；`crates/arkflow-core/test_distributed_wal/` 是 2025-09 建的**空目录**——曾起念但未做。Engine/Stream 各为单文件（`engine/mod.rs`、`stream/mod.rs`）。
+3. **无有状态计算**。仅内存 window 状态（`buffer/{session,sliding,tumbling}_window.rs`），无 state backend、无 checkpoint/savepoint、无端到端 exactly-once（当前仅 at-least-once，见 `input-durability` spec「At-least-once delivery」）。
+4. **无 CDC**。无 Debezium/binlog/PG WAL input。社区 issue #430（NoSQL output）、#274（S3 & SQL output）侧面反映企业集成诉求。
+5. **可运维性弱**。有 `prometheus` 依赖但缺完整 metrics 导出方案；无 trace；无动态配置/管理面。
+6. **processor 工具箱偏薄**。缺数据处理常用的 filter/mask/encrypt/http-lookup/schema-registry 等。
+7. **文档落后于实现**。README 的 input/output 清单不全（漏 memory/multiple_inputs/pulsar、redis/sql/influxdb/pulsar output 等）。
+
+### 1.3 生态位（2026-07-31 调研结论）
+
+**重型有状态流——不要正面竞争**：
+- **RisingWave**：92% Rust，分布式流式数据库，Snowflake 式存算分离（compute/storage 解耦，frontend/compute/meta/compactor 四类节点），状态作为数据库一等对象存对象存储；2026 路线图转向「**agentic AI** event streaming」。SQL + 物化视图为核心。
+- **Arroyo**：85% Rust，**同样基于 Apache Arrow**（与 ArkFlow 同栈），分布式有状态，exactly-once、ms 级延迟，公开 benchmark 吞吐约 RisingWave 3-5x；**2025-04 被 Cloudflare 收购**，开源项目方向生变，仍 v0.15 未到 1.0。
+- → 两者核心护城河正是「分布式 + 有状态 + EOS」。ArkFlow 投入分布式有状态 = 在强敌主场追赶，**必输**。
+
+**轻量数据管道——ArkFlow 的真正赛场**：
+- **Benthos / Bento**（现由 WarpStream Labs 维护）：配置式、声明式、插件丰富，但**官方定位 stateless**——无原生 exactly-once、无任意状态 checkpoint/snapshot，依赖上游 broker 的事务；CDC（MySQL/PG/Mongo）是近期才加、尚不成熟（端到端 EOS / schema 变更 / 删除处理有局限，见 bento#396）。
+- **Vector**：Rust，偏可观测性数据路由，行式，无复杂 SQL/状态。
+
+**关键差异化结论**：ArkFlow 与 Arroyo 的差异**不在数据模型**（都是 Arrow），而在「**单节点轻量 vs 分布式有状态**」。ArkFlow 的最佳生态位是 **「Benthos 的形态 + 生产级可靠性 + 列式 SQL」**：
+- 对 Benthos 形成**跨代差异**：ArkFlow 已有 input WAL（at-least-once + S3），Benthos 是 stateless；方向②（EOS/状态/CDC/schema）正是踩在 Benthos 公开软肋上。
+- 对 RisingWave/Arroyo 保持**轻量错位**：单二进制、配置式、不搞分布式，承接「比 Benthos 可靠、比 Flink/RisingWave 轻」的中等规模实时数据集成 / ETL 场景。
+
+**外部认知信号**：HN / Medium 把 ArkFlow 定位为「实验性」新引擎（2025 初发布）——方向②正是摘掉「实验性」标签、走向生产可用的关键。issue #284（用户问「vs Arroyo」）也印证社区在拿它与重型引擎对标，需用「轻量 + 可靠」明确错位，而非硬比分布式。
+
+> 来源：[RisingWave 2026 landscape](https://risingwave.com/blog/streaming-database-landscape-2026-complete-guide/)、[RisingWave 架构](https://docs.risingwave.com/get-started/architecture)、[RisingWave vs Arroyo](https://risingwave.com/blog/risingwave-vs-arroyo-rust-stream-processors/)、[Arroyo GitHub](https://github.com/ArroyoSystems/arroyo)、[Bento 文档（stateless）](https://warpstreamlabs.github.io/bento/)、[WarpStream 整合 Bento](https://www.warpstream.com/blog/fancy-stream-processing-made-even-more-operationally-mundane)、[Bento CDC 讨论 #396](https://github.com/warpstreamlabs/bento/discussions/396)
+
+---
+
+## 二、推荐方向清单（编号即后续 roadmap 引用）
+
+| 编号 | 方向 | 差异化 | 可行性 | 与现状关系 |
+| --- | --- | --- | --- | --- |
+| **①** | **智能流处理（AI/ML）** —— 推理 processor、异常检测、向量入库、流式 embedding/RAG | ★★★（兑现 README，但 RisingWave 已转 AI、蓝海收窄） | 中（需选推理后端） | 全新战线 |
+| **②** | **生产级端到端可靠性** —— CDC、schema registry、EOS、状态 checkpoint | ★★★（企业刚需，踩 Benthos 软肋） | 高（延续 WAL） | **直接延续过去一个月的全部投入** |
+| ③ | 可运维性（metrics/traces 导出、管理 API、动态配置） | ★★（同质化但必备） | 高 | 补当前短板 |
+| ④ | 开发者生态（WASM/外部 processor、流编排 DAG、更多 connector） | ★★（降扩展门槛，issue #88 WASM） | 高 | 长期生态 |
+
+> **本文档聚焦方向②**（用户 2026-07-31 指示）。①③④ 的 roadmap 待后续展开。
+
+---
+
+## 三、方向② Roadmap：生产级端到端可靠性
+
+### 3.1 总目标
+
+把现有的「input 级、at-least-once、单节点 WAL」升级为「**端到端、可恢复、可对接企业数据源与数据契约**」的生产级可靠性，分 4 个可独立交付的 OpenSpec change 递进完成。
+
+**战略对标**：这不是追赶 RisingWave/Arroyo（分布式有状态），而是**踩在 Benthos（stateless）的公开软肋上**——把「轻量配置式数据管道」做到生产级可靠，形成对 Benthos 的跨代差异、对重型引擎的轻量错位。边界：保持单节点，不引入分布式。
+
+### 3.2 路线图与依赖（价值优先序，2026-07-31 用户确认）
+
+```
+Change 1  CDC Input (Debezium / MySQL binlog / PG WAL)     独立，复用 WAL source-commit
+Change 2  Schema Registry 与 schema 演进治理                 独立，与 protobuf-codec 协同
+   ‖   ← 1、2 独立可并行，先交付最直接的企业集成价值
+Change 3  端到端 Exactly-Once（聚焦 output 幂等适配）         独立于 input 类型
+Change 4  有状态 Processor 的 checkpoint 与恢复              依赖 Change 3 的 ack 链路；最重，最后
+```
+
+交付顺序：**1 → 2 → 3 → 4**（1、2 可并行）。理由：CDC + schema 是「可对接企业数据源 / 数据契约」最直接的价值且彼此独立，先交付；EOS 居中深化可靠性；状态 checkpoint 最重、最接近 RisingWave/Arroyo 领域，推到最后。每个 change 走 OpenSpec：`propose → apply → verify → archive`（delta 合并入 `openspec/specs/`）。
+
+---
+
+### Change 1 — CDC Input（Debezium / MySQL binlog / PostgreSQL WAL）
+
+**Why**
+无 CDC 是企业数据集成硬缺口（社区 issue #430/#274 侧面反映）；binlog/WAL 位点天然适配 input-WAL 的 source-commit 机制（位点 = commit point）。Benthos 的 CDC 新加且不成熟（端到端 EOS / schema 变更 / 删除处理有局限，见 bento#396），ArkFlow 借 WAL 可后发做得更稳。
+
+**What Changes**
+1. 新增 CDC input（先支持 Debezium 协议 JSON 或 MySQL binlog 直连其一）。
+2. **位点管理**：把 binlog/WAL 位点作为 source-side commit，与 `input-durability` 的 ack-gated commit 复用。
+3. 配套 example 与文档。
+
+**Capabilities**
+- 新增：`cdc-ingestion`
+- 修改：`input-durability`（CDC 位点作为 source commit）
+
+**Impact（初判，propose 时核实）**
+- 新增 `crates/arkflow-plugin/src/input/cdc.rs`（或 `debezium.rs`）
+- 注册于 `input/mod.rs`
+
+---
+
+### Change 2 — Schema Registry 与 Schema 演进治理
+
+**Why**
+`protobuf-codec` 目前单文件 schema，无多版本/兼容性治理；CDC + EOS 场景下数据契约稳定是刚需（CDC 的 schema 变更是已知难题）。社区 issue 也反映对 schema 能力的关注。
+
+**What Changes**
+1. 对接 Schema Registry（Confluent / Apicurio），按 schema id 解码。
+2. **兼容性检查**（向后/向前兼容策略）。
+3. 与 protobuf-codec、CDC 数据契约协同。
+
+**Capabilities**
+- 新增：`schema-registry-integration`
+- 修改：`protobuf-codec`（支持 registry 解析）
+
+**Impact（初判）**
+- `crates/arkflow-plugin/src/processor/protobuf.rs`、`codec/`
+- 新增 registry client（`reqwest`，已在依赖）
+
+---
+
+### Change 3 — 端到端 Exactly-Once（聚焦 Output 幂等适配）
+
+**Why**
+当前 `input-durability` spec 明确为 at-least-once：crash 后重放，output 可能收到重复消息（见 spec「Duplicate delivery after recovery」）。对 Kafka/JDBC 等支持事务或幂等的 sink，重复会导致错误结果，阻碍企业生产落地。难点在 **output 端的幂等适配**（每个 sink 不同），不在 ack 链路改造。
+
+**What Changes**
+1. 为 output 引入**幂等 / 事务写入**：按 sink 适配——Kafka 事务（事务 id 由 WAL seq 派生）、JDBC upsert（dedup key 列）等。
+2. **复用现有 ack-gated cursor**（不新造两阶段 ack / epoch 机制，避免过度设计）：output 写成功 → cursor 前进 → source commit，重复时靠 sink 幂等吸收。
+3. recovery 时，已 commit 序列的重复写入由 sink 幂等兜底。
+
+**Capabilities**
+- 新增：`end-to-end-exactly-once`
+- 修改：`message-acknowledgment`（ack 携带写入 epoch 供 sink 去重，最小扩展）、`input-durability`（replay 与 sink 幂等协同）
+
+**Impact（初判）**
+- `crates/arkflow-plugin/src/output/{kafka,sql}.rs`（事务 / upsert 适配，主要工作量在此）
+- `crates/arkflow-core/src/output/mod.rs`（幂等契约 trait）
+- `crates/arkflow-core/src/wal/`（cursor seq 暴露给 sink 事务 id）
+
+---
+
+### Change 4 — 有状态 Processor 的 Checkpoint 与恢复（最重，最后）
+
+**Why**
+现状仅 window 内存状态，processor 无持久状态；crash 后窗口中间结果丢失，只能从 input WAL 重放原始流重新计算，代价高且对非幂等算子不可行。**注意**：此项最接近 RisingWave/Arroyo 的有状态计算领域，须严守「单节点、不引入分布式」边界。
+
+**What Changes**
+1. 可选 **state backend** 抽象（内存 + 嵌入式 `redb`，已存在于依赖；远期 RocksDB）。
+2. **周期性 checkpoint**：processor 快照（state + 对应 WAL seq），与 input-WAL cursor 对齐。
+3. **恢复**：startup 先恢复 processor 状态到 checkpoint，再从对应 cursor 重放（而非从零重算）。
+
+**Capabilities**
+- 新增：`processor-state-checkpoint`
+- 修改：`input-durability`（checkpoint 与 WAL cursor 协调点）、window buffer specs（状态化）
+
+**Impact（初判）**
+- 新增 `crates/arkflow-core/src/state/` 或扩展 `temporary/`
+- `crates/arkflow-core/src/processor/mod.rs`（stateful trait）、`stream/mod.rs`（checkpoint 协调）
+- 依赖 Change 3 的 ack 链路
+
+---
+
+## 四、进度与状态（2026-07-31）
+
+### 方向② 推进进度
+
+| Change | 状态 | OpenSpec 位置 | 备注 |
+| --- | --- | --- | --- |
+| **1 CDC** | ✅ 全流程闭环 | `changes/archive/2026-07-31-add-cdc-debezium`；spec `debezium-cdc-parsing` 已合并 `openspec/specs/` | `debezium_json` codec，复用 Kafka input + ack-gated offset |
+| **前置 refactor** | ✅ 全流程闭环 | `changes/archive/2026-07-31-refactor-codec-async`；spec `async-codec-contract` 已合并 | Codec trait async 化，**纯重构无行为变更**；为 schema_registry 解锁 reqwest async |
+| **2 Schema Registry** | ✅ 全流程闭环 | `changes/archive/2026-07-31-add-schema-registry`；spec `schema-registry-integration` 已合并 | reqwest async + `SchemaResolver` trait；认证 HTTP mock 测试（wiremock） |
+| **3 端到端 EOS** | ⏳ 待 propose | — | 聚焦 output 幂等适配 |
+| **4 状态 checkpoint** | ⏳ 待 propose | — | 最重、推最后；守单节点 |
+
+### 已确认决策
+- 方向② = 生产级端到端可靠性（对标 Benthos 软肋、延续 WAL 势能；详见 1.3 节）。
+- 交付顺序 = 价值优先：**1 CDC → 2 Schema → 3 EOS → 4 状态**。
+- 状态 checkpoint（Change 4）保留完整内容、推最后；守「单节点、不引入分布式」。
+- Codec trait async 化（`refactor-codec-async`）作为 IO 类 codec 的前置，独立 change。
+
+### 下一步
+propose Change 3（端到端 EOS）→ Change 4（状态 checkpoint）。

--- a/openspec/PLANNING.md
+++ b/openspec/PLANNING.md
@@ -181,7 +181,7 @@ Change 4  有状态 Processor 的 checkpoint 与恢复              依赖 Chang
 | **1 CDC** | ✅ 全流程闭环 | `changes/archive/2026-07-31-add-cdc-debezium`；spec `debezium-cdc-parsing` 已合并 `openspec/specs/` | `debezium_json` codec，复用 Kafka input + ack-gated offset |
 | **前置 refactor** | ✅ 全流程闭环 | `changes/archive/2026-07-31-refactor-codec-async`；spec `async-codec-contract` 已合并 | Codec trait async 化，**纯重构无行为变更**；为 schema_registry 解锁 reqwest async |
 | **2 Schema Registry** | ✅ 全流程闭环 | `changes/archive/2026-07-31-add-schema-registry`；spec `schema-registry-integration` 已合并 | reqwest async + `SchemaResolver` trait；认证 HTTP mock 测试（wiremock） |
-| **3 端到端 EOS** | ⏳ 待 propose | — | 聚焦 output 幂等适配 |
+| **3 端到端 EOS** | 🚧 实现 done，待 verify/archive | `changes/add-end-to-end-exactly-once` | Phase 1（write_batch 地基）✅ + Phase 2（Kafka 事务 producer）✅ + Phase 3（cp-kafka testcontainers 集成测试：smoke/atomic/fencing/dup，4 项本地通过）✅ + Phase 4（example/CLAUDE.md）✅ |
 | **4 状态 checkpoint** | ⏳ 待 propose | — | 最重、推最后；守单节点 |
 
 ### 已确认决策
@@ -189,6 +189,7 @@ Change 4  有状态 Processor 的 checkpoint 与恢复              依赖 Chang
 - 交付顺序 = 价值优先：**1 CDC → 2 Schema → 3 EOS → 4 状态**。
 - 状态 checkpoint（Change 4）保留完整内容、推最后；守「单节点、不引入分布式」。
 - Codec trait async 化（`refactor-codec-async`）作为 IO 类 codec 的前置，独立 change。
+- Change 3 EOS 形态：`Output::write_batch` 默认方法（1 ack = 1 事务单元，默认实现等价逐条）；Kafka L2 事务 producer（opt-in `exactly_once`+`transactional_id`，**显式配置而非 node_id 派生**——output build 拿不到 durability 配置，transactional.id 与 WAL node_id 是不同身份概念）；SQL L1 复用现有 upsert（零代码）。L2 诚实边界：已 commit 跨重启重复靠业务幂等；L3（Kafka→Kafka `send_offsets_to_transaction`）留 future。
 
 ### 下一步
-propose Change 3（端到端 EOS）→ Change 4（状态 checkpoint）。
+Change 3 EOS：实现完成（Phase 1-4 全 done；Phase 3 用 cp-kafka testcontainers 替代 redpanda——Kafka 事务参考实现 + CI 可拉 + 协议兼容，EOS 语义等价）。下一步 `openspec verify` → archive（spec `exactly-once-output` 合并主 specs）→ propose Change 4（状态 checkpoint）。

--- a/openspec/changes/archive/2026-07-31-add-cdc-debezium/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-cdc-debezium/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-cdc-debezium/design.md
+++ b/openspec/changes/archive/2026-07-31-add-cdc-debezium/design.md
@@ -1,0 +1,76 @@
+## Context
+
+ArkFlow 当前无 CDC 能力（见 `proposal.md` Why）。但补齐 CDC 的基础设施已就位：
+
+- Kafka input 已支持配置 codec 解码（`crates/arkflow-plugin/src/input/kafka.rs:62`、`kafka.rs:198-200` `apply_codec_to_payload`）。
+- Kafka input 的 offset 是 ack-gated 的（`kafka.rs:135-148`：`enable.auto.offset.store=false`，仅在 `KafkaAck::ack()` 内 `store_offset()`），与 `openspec/specs/input-durability` 的 ack-gated source-commit 一致。
+- codec 注册机制成熟（`crates/arkflow-plugin/src/codec/json.rs:63` `register_codec_builder("json", …)`），JSON→Arrow 解析可复用 `component::json::try_to_arrow`（见 `processor/json.rs:73`）。
+
+因此本 change 是**纯增量、零侵入**：新增一个 codec，挂到 Kafka input 现有 codec 接入点，位点完全复用现有 ack-gated offset。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 以 `debezium_json` codec 形式提供 Debezium Envelope JSON → 列式 Arrow 的解析。
+- 经 Kafka input 现有 codec 接入点接入，不新增 input 类型、不改 input 代码。
+- 一份解析逻辑覆盖 Debezium 支持的全部数据库（MySQL/PostgreSQL/MongoDB/SQLServer 等）。
+- 复用 ack-gated Kafka offset 作为 CDC 位点，保持 at-least-once。
+
+**Non-Goals:**
+- binlog / PG 逻辑复制直连（未来独立 input）。
+- Schema Registry 与 schema 演进治理（方向② Change 2）。
+- 端到端 exactly-once（方向② Change 3）。
+- Debezium Avro/Protobuf 格式（随 Change 2）。
+
+## Decisions
+
+### 决策 1：放 codec 层，而非 processor 层
+**选择**：新增 `debezium_json` **codec**，由 Kafka input 经 `apply_codec_to_payload`（`kafka.rs:198-200`）调用。
+
+**Alternatives**：
+- *processor*（如 `debezium` processor）：需先让 input 把 Debezium 字节作为 binary MessageBatch 传入 pipeline，再由 processor 展平。优点是转换逻辑可与其他 processor 组合；缺点是配置更长（input + pipeline 两处）、且把「这是一个 CDC 流」的语义下沉到 pipeline，不如在 input 层声明直观。
+- *新 input 类型*（`type: debezium_kafka`）：重复实现 Kafka 消费逻辑，违背 surgical changes。
+
+**理由**：codec 接入点已现成、配置最简（`input.codec.type: debezium_json` 一处）、CDC 是 input 流的性质；processor 方案的两步处理无额外收益。
+
+### 决策 2：Envelope 展平策略——after 扁平为顶层列 + CDC 元列 + before 保留
+Debezium Envelope：`{ before, after, op, source, ts_ms }`。
+
+**选择**：输出列 = `after` 的字段**扁平化为顶层列**（主数据行）＋ 顶层元列 `op`（`c`/`u`/`d`/`r`）、`ts_ms`、`source` 关键字段（`source_db`、`source_table` 等）＋ `before`/`source` 作为 **JSON 文本列（Utf8）**保留完整对象。
+
+> 实现发现（2026-07-31）：原计划把 `before`/`source` 作为 `StructArray` 列，但 Arrow JSON Reader 的单遍 schema 推断无法处理同一 batch 内 `null` 与 object 混合（`before` 在 insert 行为 null、update 行为 object，报 `expected null got {...}`）。故改为 JSON 文本列（稳定 Utf8，null 值序列化为 `"null"` 字面量），下游用 DataFusion JSON 函数查询；最常用的 `source_db`/`source_table` 仍为可直接 SQL 的标量顶层列。
+
+**Alternatives**：
+- *双扁平 `before_*` / `after_*`*：列数翻倍、大多数下游只关心新值，冗余。
+- *完全不展平（整体作为一个 Struct/JSON 列）*：DataFusion SQL 无法直接 `SELECT name WHERE op='u'`，违背列式 SQL 的价值。
+
+**理由**：after 扁平让下游 SQL 可直接用业务字段；`before` 作为 StructArray 保留变更前值且不爆炸列数；`op`/`ts_ms`/`source_*` 顶层列便于过滤与路由。
+
+### 决策 3：DELETE 与 snapshot 的处理
+- `op = "d"`（delete）：`after` 为 null → 顶层业务列取自 `before`，`op="d"` 标识删除（下游可据此做删除同步）。
+- `op = "r"`（snapshot/read）：当作普通行，`after` 即初始值。
+- `op = "c"/"u"`：`after` 提供新值。
+
+### 决策 4：位点管理不新增，复用 ack-gated Kafka offset
+CDC 位点即 Kafka offset，已由 `KafkaAck::ack()`（`kafka.rs:135-148`）经 `input-durability` 的 ack-gated source-commit 推进。**本 change 不引入任何位点代码**。
+
+### 决策 5：复用 `component::json` 解析，无新依赖
+Envelope 内 `before`/`after`/`source` 为 JSON 对象，复用 `component::json::try_to_arrow`（`processor/json.rs:73` 已用）做 JSON→Arrow，不引入新 crate。
+
+## Risks / Trade-offs
+
+- **[依赖外部 Debezium + Kafka Connect]** → 与「单二进制轻量」有张力。缓解：文档明确部署架构（Debezium Server / Kafka Connect → Kafka → ArkFlow）；零依赖直连作为未来独立 input 的 Non-goal。
+- **[schema 漂移（DDL 加列）]** → 同一 batch 内 Arrow schema 由推断一致；跨 batch 的 schema 演进不在本 change 范围。缓解：留给方向② Change 2（Schema Registry）。
+- **[DELETE 时 after=null 的列对齐]** → 展平时需用 before 的字段并补 null 对齐 schema。缓解：决策 3 明确取自 before，并在 specs 中以 scenario 约束。
+- **[Avro/Protobuf 格式不支持]** → Non-goal；JSON 先行，Avro 随 Schema Registry（Change 2）。
+
+## Migration Plan
+
+- 纯新增 codec + 注册，**无破坏性变更**，现有配置与行为不受影响。
+- 部署：用户在 Kafka input 下增加 `codec: { type: debezium_json }` 即启用。
+- 回滚：移除该 codec 配置或回退注册提交即可，无状态/数据迁移。
+
+## Open Questions
+
+- `source` 字段提取范围：仅 `db`/`table`/`ts_ms` 子集，还是全量保留为 StructArray？——倾向「关键字段子集 + 同时保留完整 `source` StructArray 列」，实现时定。
+- Envelope 缺失字段（如无 `transaction`）的容错策略——按「字段缺失即 null」处理，specs 约束。

--- a/openspec/changes/archive/2026-07-31-add-cdc-debezium/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-cdc-debezium/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+ArkFlow 当前不具备任何 CDC（Change Data Capture）能力：`crates/arkflow-plugin/src/input/` 下的 14 个 input 均为定时轮询或推送式数据源（如 SQL input 走周期查询 `crates/arkflow-plugin/src/input/sql.rs`，并非事件驱动的变更捕获），目录中不存在 `cdc` 或 `debezium` 实现。这使得 ArkFlow 无法承接企业数据集成中最常见的「数据库变更实时同步」场景。
+
+竞品 Benthos/Bento 虽已添加 CDC connector，但公开承认尚不成熟——端到端 exactly-once、schema 变更、DELETE 处理均存在局限（warpstreamlabs/bento#396）。ArkFlow 已具备零成本复用的基础：Kafka input 支持配置 codec 解码（`crates/arkflow-plugin/src/input/kafka.rs:62`、`kafka.rs:198-200` 的 `apply_codec_to_payload`），且其 offset 由 ack 显式推进（`kafka.rs:135-148`：`enable.auto.offset.store=false`，仅在 `KafkaAck::ack()` 中 `store_offset()`），与 `openspec/specs/input-durability` 的 ack-gated source-commit 语义一致。因此消费「Debezium → Kafka」的消息时，Kafka offset 天然即 CDC 位点——本次只需补齐 Debezium 事件的解析，即可最小侵入地获得覆盖 MySQL/PostgreSQL/MongoDB/SQLServer 等的 CDC 能力。
+
+## What Changes
+
+- 新增 `debezium_json` **codec**：将 Debezium Envelope（`before`/`after`/`op`/`source`/`ts_ms`）展平为 Arrow 列式 `MessageBatch`——输出操作类型列 `op`（`c`/`u`/`d`/`r`）、变更前/后数据、`source` 源元信息、`ts_ms` 时间戳，使下游 SQL processor 可直接按 `op` 与变更字段处理（如 `WHERE op IN ('c','u')` 取 upsert、`op='d'` 取删除）。
+- 经 Kafka input 现有 codec 接入点（`kafka.rs:198-200`）零侵入接入：用户配置 `input.codec.type: debezium_json` 即可获得 CDC 流，无需新 input 类型。
+- 位点管理复用现有机制、不新增：Kafka offset 经 ack-gated commit（`input-durability`）即 CDC 位点，保持 at-least-once。
+- 配套 example 配置与组件文档。
+
+## Non-goals
+
+- 不实现 MySQL binlog / PostgreSQL 逻辑复制**直连**（零依赖 CDC）——留作未来独立 input。
+- 不做 Schema Registry 集成与 schema 演进治理（方向② Change 2）。
+- 不做端到端 exactly-once（方向② Change 3）；本次维持 at-least-once，重复由下游 sink 幂等吸收。
+- 不支持 Debezium 的 Avro/Protobuf 序列化格式（先支持 JSON；Avro 依赖 Schema Registry，随 Change 2 落地）。
+
+## Capabilities
+
+### New Capabilities
+- `debezium-cdc-parsing`: 将 Debezium Envelope JSON 解析为列式 Arrow（`op`/`before`/`after`/`source`/`ts_ms`），以 codec 形式暴露，复用 Kafka input 的 codec 接入与 ack-gated offset 提交。
+
+### Modified Capabilities
+<!-- CDC 消费是 input-durability 的新用例，不改变其现有 requirement；ack-gated source-commit 语义对 Kafka offset（即 CDC 位点）原样适用，故无 spec 级修改。 -->
+（无）
+
+## Impact
+
+- 新增 `crates/arkflow-plugin/src/codec/debezium.rs`（codec 实现），并在 `crates/arkflow-plugin/src/codec/mod.rs:19` 的 `init()` 中注册 `register_codec_builder("debezium_json", ...)`。
+- Envelope 解析复用现有 `component::json`（参考 `crates/arkflow-plugin/src/processor/json.rs:73` 对 `try_to_arrow` 的使用），无新第三方依赖。
+- 接入点 `crates/arkflow-plugin/src/input/kafka.rs:198-200`（`apply_codec_to_payload`）无需改动。
+- 新增 example `examples/cdc_debezium.yaml` 与组件文档 `docs/docs/components/`。
+- 战略来源：`openspec/PLANNING.md` 方向② Change 1。

--- a/openspec/changes/archive/2026-07-31-add-cdc-debezium/specs/debezium-cdc-parsing/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-cdc-debezium/specs/debezium-cdc-parsing/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Debezium Envelope 解析为列式 Arrow
+`debezium_json` codec 收到 Debezium Envelope JSON（含 `before`/`after`/`op`/`source`/`ts_ms`）时，SHALL 输出列式 `MessageBatch`：`after` 的字段扁平化为顶层列（主数据行），并附加 `before`（作为 JSON 文本列）、`op`、`ts_ms` 与 `source` 元信息列。
+
+#### Scenario: create 事件
+- **WHEN** codec 解析一条 `op="c"` 的 Envelope（`after` 含新行数据，`before` 为 null）
+- **THEN** 输出 `MessageBatch` 的顶层列为 `after` 的字段值，`op` 列为 `"c"`，`before` 列为 null
+
+#### Scenario: update 事件
+- **WHEN** codec 解析一条 `op="u"` 的 Envelope（`before` 与 `after` 均非空）
+- **THEN** 顶层列为 `after` 的新值，`before` JSON 文本列保留变更前值，`op` 列为 `"u"`
+
+#### Scenario: delete 事件
+- **WHEN** codec 解析一条 `op="d"` 的 Envelope（`after` 为 null，`before` 含被删行数据）
+- **THEN** 顶层列取自 `before` 的字段值，`op` 列为 `"d"`，下游可据此识别删除
+
+#### Scenario: snapshot/read 事件
+- **WHEN** codec 解析一条 `op="r"` 的 Envelope（初始快照行）
+- **THEN** 顶层列为 `after` 的初始值，`op` 列为 `"r"`
+
+### Requirement: 操作类型列 op
+codec SHALL 在每条输出中附加顶层 `op` 列，其值为该 Envelope 的 `op` 字段原值（`c`/`u`/`d`/`r` 之一）。
+
+#### Scenario: op 值透传
+- **WHEN** Envelope 的 `op` 为 `"u"`
+- **THEN** 输出 `op` 列对应行为 `"u"`
+
+### Requirement: 源元信息列
+codec SHALL 附加 `source` 关键字段为顶层列（至少 `source_db`、`source_table`），保留完整 `source` 对象为 JSON 文本列（供下游 SQL 用 JSON 函数查询），并附加 `ts_ms` 为顶层列。`before` 同样以 JSON 文本列保留完整变更前值。
+
+#### Scenario: source 字段提取
+- **WHEN** Envelope 的 `source` 含 `db="orders"`、`table="orders"`
+- **THEN** 输出含顶层列 `source_db="orders"`、`source_table="orders"`，且完整 `source` JSON 文本列保留全部源字段
+
+#### Scenario: ts_ms 透传
+- **WHEN** Envelope 含 `ts_ms=1700000000000`
+- **THEN** 输出 `ts_ms` 顶层列为 `1700000000000`
+
+### Requirement: 字段缺失容错
+当 Envelope 的 `before`、`after` 或 `source` 缺失或为 null 时，codec SHALL 以 null 填充对应列，不得返回错误。
+
+#### Scenario: delete 时 after 为 null
+- **WHEN** 一条 `op="d"` 的 Envelope 的 `after` 为 null
+- **THEN** codec 正常输出，顶层业务列取自 `before`，未涉及的列以 null 填充，不报错
+
+#### Scenario: source 缺失
+- **WHEN** 一条 Envelope 不含 `source` 字段
+- **THEN** `source_db`/`source_table` 顶层列为 null，`source`/`before` JSON 文本列保留为 `"null"` 文本，codec 不报错
+
+### Requirement: 作为 codec 注册并经 Kafka input 接入
+`debezium_json` codec SHALL 经 `register_codec_builder` 注册，并可被 Kafka input 通过现有 codec 接入点（`apply_codec_to_payload`）调用，无需新增 input 类型或修改 input 代码。
+
+#### Scenario: Kafka input 配置 debezium_json codec
+- **WHEN** 一个 Kafka input 配置 `codec: { type: "debezium_json" }` 并读到一条 Debezium Envelope 字节
+- **THEN** input 输出的 `MessageBatch` 为该 Envelope 解析后的列式数据（含 `op`/业务列/`before`/`source_*`）
+
+#### Scenario: 未配置 codec 时行为不变
+- **WHEN** Kafka input 未配置 codec
+- **THEN** 其行为与现状完全一致，不受本 codec 存在的影响
+
+### Requirement: CDC 位点复用 ack-gated Kafka offset
+codec SHALL NOT 引入自身的位点/offset 管理；CDC 位点由 Kafka input 现有的 ack-gated offset 承担（消费位点经 `input-durability` 的 ack-gated source-commit 推进）。
+
+#### Scenario: 位点推进与 input-durability 一致
+- **WHEN** 下游确认写入、Kafka input 的 ack 被触发
+- **THEN** Kafka offset 按 `input-durability` 现有语义推进，codec 不参与位点逻辑

--- a/openspec/changes/archive/2026-07-31-add-cdc-debezium/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-cdc-debezium/tasks.md
@@ -1,0 +1,36 @@
+## 1. Codec 核心实现
+
+- [x] 1.1 创建 `crates/arkflow-plugin/src/codec/debezium.rs`，定义 `DebeziumJsonCodec` 并实现 `Decoder`（参考 `codec/json.rs` 的结构）
+- [x] 1.2 实现 Envelope 解析：把 `after` 字段扁平化为 Arrow 顶层列（复用 `component::json::try_to_arrow`，参考 `processor/json.rs:73`）
+- [x] 1.3 附加顶层元列 `op`、`ts_ms`，以及 `source_db`/`source_table` 顶层列 + 完整 `source`（JSON 文本列）
+- [x] 1.4 `before` 作为 JSON 文本列保留；`op="d"` 时顶层业务列取自 `before`
+- [x] 1.5 字段缺失容错：`before`/`after`/`source` 缺失或为 null 时以 null/`"null"` 填充，不报错
+- [x] 1.6 `cargo build --package arkflow-plugin` 通过
+
+## 2. 注册与元数据
+
+- [x] 2.1 在 `codec/debezium.rs` 实现 `pub(crate) fn init()`，调用 `register_codec_builder("debezium_json", Arc::new(DebeziumJsonCodecBuilder))`（参考 `codec/json.rs:62-63`）
+- [x] 2.2 在 `crates/arkflow-plugin/src/codec/mod.rs` 的 `init()` 中追加 `debezium::init()?;`
+- [x] 2.3 按 codec 现有元数据注册模式注册 `ComponentMetadata::with_schema`（含 codec 配置 schema），供 `components list/show/schema` 发现
+- [x] 2.4 `./target/debug/arkflow components show codec debezium_json` 正确输出 schema（kind/description/schema）
+
+## 3. 测试
+
+- [x] 3.1 单元测试：`op="c"/"u"/"d"/"r"` 四种事件解析正确（含 `op`/业务列/`source_db` 断言）
+- [x] 3.2 单元测试：`op="d"`（`after=null`）顶层业务列取自 `before`、不报错
+- [x] 3.3 单元测试：`before`/`source` 缺失时的容错（不报错）
+- [x] 3.4 单元测试：`source_db`/`source_table`/`ts_ms`/`before`/`source`（JSON 文本）提取正确
+- [x] 3.5 `cargo test --package arkflow-plugin codec::debezium` 全绿（9 passed）
+- [x] 3.6 `cargo test --workspace --lib` 全绿（core 142 + plugin 209，无回归）
+
+## 4. Example 与文档
+
+- [x] 4.1 新增 `examples/cdc_debezium.yaml`：Kafka input + `codec: { type: debezium_json }` + SQL processor 按 `op` 路由
+- [x] 4.2 新增 `docs/docs/components/5-codecs/`（`_category_.json` + `debezium.md`）：Envelope 字段说明、部署架构、输出 schema、交付语义
+- [x] 4.3 `./target/debug/arkflow --config examples/cdc_debezium.yaml --validate` 通过（EXIT=0）
+
+## 5. 质量门禁
+
+- [x] 5.1 `cargo clippy --package arkflow-plugin` 对 `debezium.rs` 无告警（workspace 预存 warning 非本次引入）
+- [x] 5.2 `cargo build --release --package arkflow` 通过（exit 0）
+- [x] 5.3 CLAUDE.md codec 清单补 `Debezium`（line 89 + Codec Components 节）；README 无 codec 清单，不补

--- a/openspec/changes/archive/2026-07-31-add-schema-registry/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-schema-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-schema-registry/design.md
+++ b/openspec/changes/archive/2026-07-31-add-schema-registry/design.md
@@ -1,0 +1,79 @@
+## Context
+
+当前 protobuf codec 在 build 时从本地 `.proto` 构建固定 `MessageDescriptor`（`codec/protobuf.rs:68-88`），decode 用该固定 descriptor（`:97-118`），不支持多版本/动态 schema/Confluent wire format（见 `proposal.md`）。可复用基础已就位：
+
+- `component::protobuf::protobuf_to_arrow`（`component/protobuf.rs:131`）——payload → Arrow 解码逻辑，可直接复用。
+- `component::protobuf::parse_proto_file`（`:68`）——从**文件路径**解析；registry 返回 .proto **字符串**，需新增"从字符串解析"的能力。
+- `reqwest` 已在 `arkflow-plugin/Cargo.toml:42`，无需新依赖做 HTTP。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增 `schema_registry` codec：Confluent wire format（`0x00` + schema id + payload）→ 按 id 从 Schema Registry 拉 Protobuf schema → 动态解码。
+- 多版本 schema 天然支持（不同 id 用不同 descriptor）。
+- 按 id 缓存 descriptor，避免每消息 HTTP。
+- 复用 `component::protobuf` 解码；最小侵入现有 protobuf codec。
+
+**Non-Goals:**
+- Avro / JSON Schema 类型（先 Protobuf）。
+- 显式兼容性检查（BACKWARD/FORWARD）——由 registry 端保证。
+- 写入 registry（只读消费）。
+- Protobuf schema references（import 其他 schema）——先单文件 schema。
+- 修改现有 `protobuf` codec 行为。
+
+## Decisions
+
+### 决策 1：独立 `schema_registry` codec，而非扩展 protobuf codec
+**选择**：新增独立 codec。
+
+**Alternatives**：
+- *扩展 protobuf codec 加 registry 模式*：`ProtobufCodec` 持有固定 descriptor，改动态需重构 decode（per-message 拉 schema），侵入大、违背 surgical。
+- *新 processor*：wire format 解析 + schema 拉取是 input 解码职责，非 pipeline transform。
+
+**理由**：wire format + HTTP + 动态 schema 是独立职责；独立 codec 零侵入现有 protobuf codec，复用 `component::protobuf` 解码。
+
+### 决策 2：Confluent wire format
+消息 = `[0x00][schema_id: 4 字节大端][payload]`。decode 剥前 5 字节，校验 magic=`0x00`，读 schema id，余为 payload。Confluent 是 Kafka 生态事实标准，不自造格式。
+
+### 决策 3：`SchemaResolver` trait 抽象 + REST 实现 + 按 id 缓存
+**选择**：定义 `SchemaResolver` trait（`fetch_schema(id) -> Protobuf schema 字符串`）。生产用 `RestSchemaResolver`（reqwest，`GET {registry}/schemas/ids/{id}`，可选 Basic/bearer auth）；测试用 `InMemorySchemaResolver`（无需 HTTP mock）。codec 持 `Arc<dyn SchemaResolver>` + 按 id 缓存 `MessageDescriptor`。
+
+**Alternatives**：直接在 codec 内嵌 reqwest——可测性差（需 HTTP mock crate）。
+
+**理由**：trait 抽象让 wire format + 缓存 + 多版本逻辑可纯单元测试（InMemoryResolver），REST 仅是 resolver 的一个实现。
+
+### 决策 4：复用 `component::protobuf`，扩展 schema 来源
+`protobuf_to_arrow`（`:131`）直接复用。新增 `component::protobuf::parse_proto_source(schema: &str) -> MessageDescriptor`（从 .proto 字符串解析，复用 `protobuf-parse`，已在依赖），供 registry schema 使用。`parse_proto_file`（文件路径）保持不变。
+
+### 决策 5：多版本天然支持
+不同 schema id → 不同 descriptor → 按 id 缓存。decode 用 per-message schema id 对应的 descriptor。无需显式版本管理；schema 演进产生新 id，旧 id descriptor 仍可用。
+
+### 决策 6：依赖前置 change `refactor-codec-async`（Codec trait async 化）
+schema_registry codec 的 `decode` 需经 reqwest **异步**拉取 schema，但现有 `Decoder` 是 sync trait（`core/codec/mod.rs`）。在 tokio runtime 内用 `reqwest::blocking` 会 panic；纯 sync HTTP（ureq）会阻塞 tokio worker（anti-pattern）。
+
+**选择**：Codec trait async 化作为**独立前置 change** `refactor-codec-async`（见 `openspec/changes/refactor-codec-async/`），先于本 change 完成并归档。本 change 的 `RestSchemaResolver` 随之用 reqwest async（无阻塞），本身不再含 trait 重构（原 phase 0 已移出）。
+
+**影响面**（grep 实测，2026-07-31，归 refactor-codec-async 承接）：trait 定义 + json/protobuf/debezium 3 个 codec impl + input/output `codec_helper` ~5 个包装 fn + ~15 个调用点加 `.await` ≈ 20-25 处机械编辑，**逻辑零变更**。
+
+**Alternatives**：sync ureq（阻塞 worker + 新依赖）、`block_in_place`（局部技巧，每个 IO codec 重复）——均不如独立 async 重构干净。
+
+**理由**：把无行为变更的重构独立成 change，可独立验证（全绿即无回归）、独立 review；本 change 聚焦 schema_registry 功能。
+
+## Risks / Trade-offs
+
+- **[首次 schema HTTP 延迟]** → 按 id 缓存（首次后零 HTTP）；预热为 Non-goal。
+- **[registry 不可达]** → decode 返回 `Error`（明确失败，不静默）；本地 fallback 为 Non-goal。
+- **[Protobuf schema references]** → 先 Non-goal（单文件 schema）；若实际常见再补。
+- **[认证复杂度]** → 先 Basic + bearer；mTLS 等后续。
+- **[schema 字符串解析与文件解析差异]** → 复用同一 `protobuf-parse`，行为一致；测试覆盖。
+
+## Migration Plan
+
+- 纯新增 codec + `component::protobuf` 加一个 pub fn，**无破坏性变更**。
+- 部署：input/output 配 `codec: { type: "schema_registry", registry_url, message_type, ... }`。
+- 回滚：移除 codec 配置或回退注册。
+
+## Open Questions
+
+- schema references（Confluent Protobuf 支持引用其他 schema）——先 Non-goal，实现时确认生产常见度。
+- 缓存上限/淘汰——按 id 缓存（id 不可变），若 schema 版本极多需加上限（LRU）；先无界，按需加。

--- a/openspec/changes/archive/2026-07-31-add-schema-registry/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-schema-registry/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+ArkFlow 的 protobuf-codec 仅支持本地 `.proto` 文件、在 build 时固定**单一** message descriptor（`crates/arkflow-plugin/src/codec/protobuf.rs:42-49` 的 `ProtobufCodecConfig`、`:68-88` 的 `new()` 从 `parse_proto_file` 构建固定 `MessageDescriptor`、`:97-118` 的 `decode` 用该固定 descriptor）。这使其无法处理：
+
+1. **多 schema 版本**——消息可能由不同版本的序列化器产生（schema 演进），固定 descriptor 无法适配；
+2. **Confluent wire format**——Kafka 生态的事实标准：`0x00` magic byte + 4 字节 schema id + payload（`protobuf.rs:97-118` 当前直接把整个字节当 payload，不识别 schema id 前缀）；
+3. **动态 schema 获取**——需运行时从 Schema Registry 按 id 拉取，而非 build 时读文件。
+
+CDC 场景（Change 1 `add-cdc-debezium`）尤其需要：源表 schema 演进（加列/改类型）时，生产者按新 schema 注册到 Schema Registry，消费者必须按 schema id 解码——Benthos 的 CDC 也受 schema 变更困扰（warpstreamlabs/bento#396）。无 Schema Registry 集成，ArkFlow 无法接入 Confluent / Debezium+Schema Registry 企业生态。
+
+## What Changes
+
+- 新增 `schema_registry` codec：按 **Confluent wire format** 解析消息（剥 `0x00` + schema id + payload），按 schema id 经 **Confluent Schema Registry REST API**（`GET /schemas/ids/{id}`）拉取 Protobuf schema（带按 id 缓存，避免每消息 HTTP），动态构建 `MessageDescriptor` 解码 payload——天然支持多版本。
+- 复用 `component::protobuf` 的 `protobuf_to_arrow` 解码逻辑；按需扩展 schema 来源（从 registry 返回的 schema 字符串解析 proto，而非仅本地文件）。
+- codec 配置：registry URL、可选认证、message type、缓存策略。
+- 配套 example 与组件文档。
+
+## Non-goals
+
+- **Avro / JSON Schema** 类型（先 Protobuf；Avro registry 后续）。
+- **显式兼容性检查**（BACKWARD/FORWARD 校验工具）——由 Schema Registry 端配置保证，本 change 只做消费端按 id 解码。
+- **写入 registry**（注册新 schema）——先只读消费。
+- **Schema Registry 服务端实现**——只做 client。
+- 修改现有 `protobuf` codec 行为（新 codec 独立，`protobuf-codec` spec 不变）。
+
+## Capabilities
+
+### New Capabilities
+- `schema-registry-integration`: 按 Confluent wire format 的 schema id 从 Schema Registry 动态获取 Protobuf schema 并解码，支持多版本 schema 演进。
+
+### Modified Capabilities
+<!-- 新 codec 独立；component::protobuf 内部按需扩展 schema 来源属实现细节，不改变 protobuf-codec 的 spec 行为。 -->
+（无）
+
+## Impact
+
+- 新增 `crates/arkflow-plugin/src/codec/schema_registry.rs`（codec + Schema Registry HTTP client + schema 缓存 + wire format 解析）。
+- 可能扩展 `crates/arkflow-plugin/src/component/protobuf.rs`（从 registry schema 字符串解析 proto，复用 `protobuf_to_arrow`）。
+- 注册于 `crates/arkflow-plugin/src/codec/mod.rs` 的 `init()`。
+- 依赖：`reqwest`（已在 workspace deps）；Confluent REST client 手写（无新重型 crate）。
+- 新增 `examples/schema_registry.yaml` 与 `docs/docs/components/5-codecs/schema-registry.md`。
+- 战略来源：`openspec/PLANNING.md` 方向② Change 2；与 Change 1（CDC）协同。

--- a/openspec/changes/archive/2026-07-31-add-schema-registry/specs/schema-registry-integration/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-schema-registry/specs/schema-registry-integration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Confluent wire format 解析
+`schema_registry` codec 收到消息字节时，SHALL 按 Confluent wire format 解析：首字节为 magic（MUST 为 `0x00`），随后 4 字节为大端 schema id，其余为 payload。magic 不为 `0x00` 或消息短于 5 字节时 SHALL 返回错误。
+
+#### Scenario: 有效 wire format
+- **WHEN** codec 收到 `0x00 0x00 0x00 0x00 0x01 <payload>`
+- **THEN** 剥出 schema id=1 与 payload，进入按 id 解码
+
+#### Scenario: magic byte 非法
+- **WHEN** 消息首字节不为 `0x00`
+- **THEN** codec 返回错误，不尝试解码
+
+#### Scenario: 消息过短
+- **WHEN** 消息不足 5 字节
+- **THEN** codec 返回错误
+
+### Requirement: 按 schema id 从 Schema Registry 获取 schema
+codec SHALL 经 Schema Registry（Confluent REST：`GET {registry}/schemas/ids/{id}`）按 schema id 获取 Protobuf schema，并构建 `MessageDescriptor` 解码 payload。registry 返回错误（非 200 或连接失败）时 SHALL 返回错误。
+
+#### Scenario: 首次拉取 schema
+- **WHEN** codec 遇到一个未缓存的 schema id
+- **THEN** 向 registry 请求 schema，构建 descriptor 解码 payload
+
+#### Scenario: registry 不可达
+- **WHEN** registry 返回非 200 或连接失败
+- **THEN** codec 返回错误，不静默跳过
+
+### Requirement: 按 schema id 缓存 descriptor
+codec SHALL 按 schema id 缓存已构建的 `MessageDescriptor`，使同一 id 的后续消息不再发起 registry 请求。
+
+#### Scenario: 重复 id 命中缓存
+- **WHEN** codec 连续遇到同一 schema id 的多条消息
+- **THEN** 仅首次发起 registry 请求，后续命中缓存解码
+
+### Requirement: 多版本 schema 解码
+codec SHALL 支持同一流中不同 schema id（不同 schema 版本）的消息，各自用对应版本的 descriptor 解码。
+
+#### Scenario: 同 batch 多版本
+- **WHEN** 一个 batch 含 schema id=1 与 schema id=2 的消息（两版 schema）
+- **THEN** 各自用对应 descriptor 解码，不互相干扰
+
+### Requirement: 作为 codec 注册并可配置
+`schema_registry` codec SHALL 经 `register_codec_builder` 注册，配置至少含 registry URL 与 message type；可经 input/output 的 codec 接入点使用。
+
+#### Scenario: 配置 codec
+- **WHEN** 一个 input 配置 `codec: { type: "schema_registry", registry_url: "...", message_type: "..." }`
+- **THEN** codec 按 registry 解码消息，未配置时现有 codec 行为不受影响
+
+### Requirement: 可选认证
+codec SHALL 支持可选的 registry 认证（Basic auth 或 bearer token），经配置提供。
+
+#### Scenario: 配置 Basic auth
+- **WHEN** codec 配置含 `auth: { type: "basic", username, password }`
+- **THEN** registry 请求携带 Basic Authorization 头

--- a/openspec/changes/archive/2026-07-31-add-schema-registry/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-schema-registry/tasks.md
@@ -1,0 +1,40 @@
+## 1. component::protobuf 扩展（schema 来源）
+
+- [x] 1.1 新增 `pub fn parse_proto_source(schema: &str, message_type: &str) -> Result<MessageDescriptor, Error>`（从 .proto 字符串解析，复用 `protobuf-parse`，参考现有 `parse_proto_file` `component/protobuf.rs:68`）
+- [x] 1.2 `parse_proto_source` 由 schema_registry 测试间接覆盖（decode_single / cache / multi-version 均经它解析）
+- [x] 1.3 `cargo build --package arkflow-plugin` 通过（tempfile 已从 dev-deps 移到 dependencies）
+
+## 2. schema_registry codec 核心
+
+- [x] 2.1 创建 `crates/arkflow-plugin/src/codec/schema_registry.rs`，定义 `SchemaRegistryCodec`（持有 `Arc<dyn SchemaResolver>` + 按 id 的 `DashMap` descriptor 缓存 + message_type）
+- [x] 2.2 定义 `SchemaResolver` trait（`async fn fetch_schema(&self, id: u32) -> Result<String, Error>`）
+- [x] 2.3 Confluent wire format 解析（剥 `0x00` + 4 字节大端 schema id + payload，校验 magic 与长度）
+- [x] 2.4 `RestSchemaResolver`（**reqwest async**，`GET {registry}/schemas/ids/{id}`，可选 Basic/bearer auth；依赖 refactor 的 async Codec）
+- [x] 2.5 按 id 缓存 descriptor（`DashMap`；命中跳过 HTTP）
+- [x] 2.6 `decode`：wire format → id → resolver 拉/缓存 schema → `parse_proto_source` → `protobuf_to_arrow` 解码
+- [x] 2.7 `cargo build --package arkflow-plugin` 通过
+
+## 3. 注册与元数据
+
+- [x] 3.1 `schema_registry.rs` 的 `init()`：`register_codec_builder("schema_registry", ...)` + `ComponentMetadata::with_schema`（registry_url / message_type / auth）
+- [x] 3.2 `crates/arkflow-plugin/src/codec/mod.rs` 的 `init()` 追加 `schema_registry::init()?;`
+- [x] 3.3 `./target/debug/arkflow components show codec schema_registry` 正确输出（描述/kind/schema）
+
+## 4. 测试
+
+- [x] 4.1 单元测试：wire format 解析（有效 / 非法 magic / 过短）—— `InMemorySchemaResolver`
+- [x] 4.2 单元测试：缓存命中（同 id 多消息只 resolve 一次）—— `fetch_count` 断言
+- [x] 4.3 单元测试：多版本（同 batch id=1 与 id=2 各自正确解码，fetch_count=2）
+- [x] 4.4 单元测试：registry 错误（resolver 返回 Err）→ decode 返回 Err
+- [x] 4.5 `cargo test --package arkflow-plugin codec::schema_registry` 全绿（7 passed）
+- [x] 4.6 `cargo test --workspace --lib` 全绿（core 142 + plugin 217，无回归）
+- [x] 4.7 RestSchemaResolver 认证 HTTP mock 测试（Basic/Bearer → Authorization 头，wiremock）—— 9 passed
+
+## 5. Example、文档与门禁
+
+- [x] 5.1 新增 `examples/schema_registry.yaml`
+- [x] 5.2 新增 `docs/docs/components/5-codecs/schema-registry.md`
+- [x] 5.3 `./target/debug/arkflow --config examples/schema_registry.yaml --validate` EXIT=0
+- [x] 5.4 `cargo clippy --package arkflow-plugin` 对 schema_registry 无告警
+- [x] 5.5 `cargo build --release --package arkflow` 通过（Finished，19m）
+- [x] 5.6 CLAUDE.md codec 清单补 `Schema Registry`

--- a/openspec/changes/archive/2026-07-31-refactor-codec-async/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-refactor-codec-async/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-refactor-codec-async/design.md
+++ b/openspec/changes/archive/2026-07-31-refactor-codec-async/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Codec trait 当前 sync（`core/codec/mod.rs:23-31`）：`Encoder::encode` / `Decoder::decode` 均为同步 fn，使 codec 内无法做异步 IO。首例需求是 `add-schema-registry` 的 schema_registry codec（按 id 异步查 Schema Registry），后续网络类 codec 同理。`async-trait` 已在 workspace deps；codec 注册机制（`register_codec_builder`）不变。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Encoder`/`Decoder`/`Codec` trait 的 encode/decode 为 async。
+- 现有 json/protobuf/debezium codec 行为完全不变（纯重构）。
+- 现有测试全绿（回归保证）。
+
+**Non-Goals:**
+- 改 codec 编解码行为/语义。
+- 新增 codec 或 IO 实现。
+- 改 input/output/buffer trait。
+
+## Decisions
+
+### 决策 1：`#[async_trait]` + `async fn`
+`Encoder`、`Decoder` 各加 `#[async_trait]`，`encode`/`decode` 改 `async fn ... -> Result<..., Error>`。`Codec` 是 `Encoder + Decoder` 的 super-trait 组合（`impl<T> Codec for T where T: Encoder + Decoder`），无需单独 async 化。
+
+### 决策 2：分步重构（编译器驱动）
+顺序：① trait（core）→ ② 3 个 codec impl → ③ codec_helper 包装 fn → ④ 调用点 `.await`。每步 `cargo build` 推进；漏 `.await` 由编译器逐个抓（机械错误，不会静默）。
+
+### 决策 3：行为不变验证
+现有 codec 测试覆盖回归：json round-trip（`codec/json.rs` tests）、protobuf round-trip（`codec/protobuf.rs` `test_codec_round_trip`）、debezium 10 测试。`cargo test --workspace --lib` 全绿即视为无行为变更。
+
+## Risks / Trade-offs
+
+- **[调用点多，漏 `.await`]** → 编译器逐个抓；分步 build 控制范围。
+- **[`async_trait` 的 boxed future 开销]** → codec 调用多数按 batch 而非 per-row，频率非超高频，可接受；换 async IO 能力值得。
+- **[重构面广]** → ~20 处，但逻辑零变更、纯机械。
+- **[`memory.rs:62` 在 sync `new()` 内 decode initial messages]** → `new()` 是 sync（被 `InputBuilder::build` 调），无法 `.await` async codec。用 `block_in_place` + `Handle::block_on` 保持构建时 decode 行为（无变更）；现有 memory test 均 `codec=None` 不触发该路径，生产部署为 multi-thread tokio runtime（满足 `block_in_place` 前提）。
+
+## Migration Plan
+
+纯重构，**无配置/数据迁移**；codec 是内部 trait（非公开 API），无外部破坏。回滚：`git revert`。
+
+## Open Questions
+
+- 无（机械重构，路径确定）。

--- a/openspec/changes/archive/2026-07-31-refactor-codec-async/proposal.md
+++ b/openspec/changes/archive/2026-07-31-refactor-codec-async/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+未来 IO 类 codec（首当其冲是 `add-schema-registry` 的 schema_registry codec）需要在 `decode` 内做异步 IO（如 HTTP 查询 Schema Registry），但 `Encoder`/`Decoder` 是 **sync** trait（`crates/arkflow-core/src/codec/mod.rs:23-31`）。在 tokio runtime 内：用 `reqwest::blocking` 会 panic（"Cannot start a runtime from within a runtime"）；用纯 sync HTTP（ureq）会阻塞 tokio worker thread（anti-pattern）。因此需先把 Codec trait async 化，作为 IO 类 codec 的前置基础。
+
+## What Changes
+
+- `Encoder`/`Decoder`（及组合 trait `Codec`）的 `encode`/`decode` 改为 `async`（`#[async_trait]`）。
+- json / protobuf / debezium 三个 codec 实现的 `encode`/`decode` 改 `async`（**逻辑零变更**）。
+- `input/codec_helper.rs` 的 `apply_codec_to_payload(s)`、`output/codec_helper.rs` 的 encode 包装改 `async fn`。
+- 所有调用点加 `.await`：input（mqtt/nats/generate/memory/pulsar/websocket/redis/http）、output（sql/influxdb 等）、`memory.rs`、`temporary/redis.rs`、`buffer/join.rs`。
+- **纯重构，无行为变更。**
+
+## Non-goals
+
+- 不改变任何 codec 的编解码行为或语义。
+- 不新增 codec、不引入 IO（schema_registry 在 `add-schema-registry`）。
+- 不改 input/output/buffer 的其他 trait。
+
+## Capabilities
+
+### New Capabilities
+- `async-codec-contract`: Codec 的 `encode`/`decode` 为 `async`，使 codec 实现可执行异步 IO；现有 codec 行为不变。
+
+### Modified Capabilities
+<!-- 纯重构，json/protobuf/debezium 的编解码行为不变，故无 spec 级修改。 -->
+（无）
+
+## Impact
+
+- `crates/arkflow-core/src/codec/mod.rs`（trait）
+- `crates/arkflow-plugin/src/codec/{json,protobuf,debezium}.rs`（impl）
+- `crates/arkflow-plugin/src/input/codec_helper.rs`、`output/codec_helper.rs`（包装 fn）
+- 调用点：`input/{mqtt,nats,generate,memory,pulsar,websocket,redis,http}.rs`、`output/{sql,influxdb}.rs`、`memory.rs`、`temporary/redis.rs`、`buffer/join.rs`
+- 依赖：`async-trait`（已在 workspace deps）
+- 前置于 `add-schema-registry`

--- a/openspec/changes/archive/2026-07-31-refactor-codec-async/specs/async-codec-contract/spec.md
+++ b/openspec/changes/archive/2026-07-31-refactor-codec-async/specs/async-codec-contract/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Codec 编解码为异步
+`Encoder`/`Decoder`（及 `Codec`）trait 的 `encode`/`decode` 方法 SHALL 为 `async`，使 codec 实现可在方法体内执行异步 IO。现有 json/protobuf/debezium codec 的编解码行为与语义 SHALL 保持不变。
+
+#### Scenario: 现有 codec 行为不变
+- **WHEN** json/protobuf/debezium codec 经 async `encode`/`decode` 调用
+- **THEN** 输入输出与重构前（sync）完全一致（现有 round-trip 与单元测试全绿）
+
+#### Scenario: codec 实现可执行异步 IO
+- **WHEN** 一个 codec 的 `decode` 需要异步操作（如 HTTP 查询外部服务）
+- **THEN** 可在 async `decode` 内 `.await` 该操作，不阻塞 tokio runtime

--- a/openspec/changes/archive/2026-07-31-refactor-codec-async/tasks.md
+++ b/openspec/changes/archive/2026-07-31-refactor-codec-async/tasks.md
@@ -1,0 +1,31 @@
+## 1. Codec trait async 化
+
+- [x] 1.1 `crates/arkflow-core/src/codec/mod.rs`：`Encoder`/`Decoder` 加 `#[async_trait]`，`encode`/`decode` 改 `async fn`（`Codec` 组合 trait 不变）
+- [x] 1.2 `cargo build --package arkflow-core` 通过
+
+## 2. codec 实现 async 化（逻辑不变）
+
+- [x] 2.1 `codec/json.rs`：`encode`/`decode` 改 `async`
+- [x] 2.2 `codec/protobuf.rs`：`encode`/`decode` 改 `async`
+- [x] 2.3 `codec/debezium.rs`：`encode`/`decode` 改 `async`
+- [x] 2.4 `cargo build --package arkflow-plugin` 通过
+
+## 3. codec_helper 包装 async 化
+
+- [x] 3.1 `input/codec_helper.rs`：`apply_codec_to_payload` / `apply_codec_to_payloads` 改 `async fn`
+- [x] 3.2 `output/codec_helper.rs`：`apply_codec_encode` 改 `async fn`
+
+## 4. 调用点加 `.await`
+
+- [x] 4.1 input：mqtt / nats / pulsar / generate / memory(:87) / websocket / http / redis / kafka 的 codec 调用加 `.await`
+- [x] 4.2 output：sql / influxdb / kafka / mqtt / nats / pulsar / http / stdout / redis 加 `.await`
+- [x] 4.3 `buffer/join.rs`、`temporary/redis.rs` 的 codec 调用加 `.await`
+- [x] 4.4 `memory.rs:62`（sync `new` 内）：用 `block_in_place` + `Handle::block_on`（构建时 decode initial messages，保持行为；现有 test 均 codec=None 不触发）
+- [x] 4.5 codec 测试同步 async 化（json/protobuf/debezium 的 `#[tokio::test]` + `.await`）
+- [x] 4.6 `cargo build --workspace` 通过
+
+## 5. 回归验证
+
+- [x] 5.1 `cargo test --workspace --lib` 全绿（core 142 + plugin 210，无回归）
+- [x] 5.2 `cargo clippy --package arkflow-core --package arkflow-plugin` 无 error
+- [x] 5.3 `--validate examples/cdc_debezium.yaml` EXIT=0

--- a/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/design.md
+++ b/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Today's pipeline is at-least-once. The ack chain is sound — `input.read() → wal.append → WalAck(wal, seq, source_ack)`, and `do_output` only calls `ack.ack()` after the output confirms the write (`crates/arkflow-core/src/stream/mod.rs:465-484`), so a failed write withholds cursor advancement and triggers replay. The duplicate exposure comes from two places:
+
+1. **Non-atomic per-message write within one ack range** — `do_output` loops `output.write(msg)` per message (`stream/mod.rs:469-477`). A partial failure already writes some rows, then the whole range is replayed.
+2. **Asynchronous source offset commit** — `KafkaAck::ack()` only calls `store_offset`; the real commit is librdkafka's periodic auto-commit (`input/kafka.rs:285-294`), so the duplicate window is the auto-commit interval (default 5s), not just the crash instant.
+
+**Spike result (rdkafka 0.38 async transactions):** confirmed feasible. `FutureProducer` implements the full transactional `Producer` trait — `init_transactions` / `begin_transaction` / `send_offsets_to_transaction` / `commit_transaction` / `abort_transaction` are all wired (`rdkafka-0.38.0/src/producer/future_producer.rs:388,410-434`), and the docs state "All records sent after starting a transaction and before committing… will automatically be associated with that transaction" (`producer/mod.rs:92-93`) — so the existing `send_result` path needs no special transactional send method. The earlier assumption that async transaction support was incomplete was wrong.
+
+This change adds an effectively-once layer on top of the unchanged at-least-once base, by giving outputs a transaction-unit boundary and implementing it for Kafka (L2) and SQL (L1).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One unified output write path (`write_batch`) where one ack range = one transaction unit.
+- Kafka output reaches L2 (transactional producer, atomic multi-message writes, zombie fencing).
+- SQL output reaches L1 (idempotent upsert) reusing the existing config.
+- Zero behavior change for the 8 outputs that don't need EOS (they inherit the default).
+- An honest, spec-grade statement of what L2 does and does not guarantee.
+
+**Non-Goals:** (see proposal.md) L3 true end-to-end EOS; stateful checkpoint (Change 4); idempotent adapters for other outputs; distributed/HA; modifying the `Ack` trait.
+
+## Decisions
+
+### D1 — `write_batch` as a default trait method (not a new trait, not a signature change)
+
+**Choice:** Keep `Output::write(msg)` and add `write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error>` with a default implementation. `do_output` calls only `write_batch`.
+
+**Alternatives considered:**
+
+| Alt | Rejected because |
+|---|---|
+| Replace `write` with `write(msgs)` (pure batch) | Forces all 10 outputs to change; gains nothing over a default method. |
+| `write(msg, ctx)` with a transaction context | Doesn't itself solve atomicity (still per-message); ctx is dead weight for non-EOS outputs. |
+| Separate `ExactlyOnceOutput` trait + downcast dispatch | Two stream-level write paths and runtime downcast — long-term maintenance burden. |
+
+A default method gets the single-path benefit of a rewrite, the zero-breakage of an opt-in trait, and needs no dispatch — strictly better than the alternatives. This is the core simplification versus PLANNING.md's initial instinct.
+
+### D2 — Default implementation is continue-on-error
+
+The default `write_batch` loops `write` and collects the last error, returning `Err` if any failed — **byte-for-byte equivalent to today's** `do_output` loop (`stream/mod.rs:469-483`). This is the guarantee that the 8 inheriting outputs have zero behavior change. (Fail-fast `?` was rejected because it would change which messages get written before a failure surfaces.)
+
+### D3 — Transaction boundary = buffer aggregation unit
+
+`ProcessorData::Ok(Vec<MessageBatchRef>)` is already ack-aligned (one `ProcessResult` carries one ack). Window/join buffers aggregate acks into `VecAck` / `ArrayAck` (`buffer/window.rs:135,145`, `buffer/memory.rs:134`), so a buffered batch's ack already represents all its constituent input acks. Therefore **one `write_batch` call ⇄ one (possibly composite) ack ⇄ one transaction** holds in *all* buffer modes — no buffer loses acks (verified for memory/window/sliding/tumbling/session/join). Consequence: transaction granularity equals the buffer's aggregation unit, so window size bounds transaction size.
+
+### D4 — Kafka transactional producer; blocking calls off the async worker
+
+`write_batch` override: `begin_transaction → send_result × N → commit_transaction`. `commit_transaction` / `init_transactions` are synchronous broker round-trips (`base_producer.rs:590`), so they run inside `spawn_blocking` to avoid stalling the tokio worker. Errors map to rdkafka's three transactional states (`producer/mod.rs:104-114`): `is_retriable` → retry the op; `txn_requires_abort` → `abort_transaction` then re-begin; `is_fatal` → propagate (producer must be discarded). `init_transactions` runs once at `connect()`.
+
+### D5 — `transactional_id` configured explicitly on the Kafka output
+
+**Choice:** the Kafka output gains `exactly_once: bool` (default `false`) and `transactional_id: String` (required when `exactly_once: true`). The user owns the id and MUST keep it stable across restarts so the broker can fence prior producer epochs.
+
+**Rationale:** `transactional.id` (Kafka producer zombie-fencing identity) and `node_id` (the WAL's namespace inside a shared object-store bucket) are different identity concepts. Coupling them would require the output to read the durability config, but output and durability are peer configs under a stream and `Output::build()` has no access to `WalConfig` — `Resource` carries only `temporary` and `input_names` (`lib.rs:115`), and there is no global node identity on `EngineConfig`. An explicit id decouples the two, mirrors how Kafka Streams / Benthos configure `transactional.id`, and avoids any BREAKING change to the WAL config or core.
+
+**Alternatives rejected:** (A) promote a global `EngineConfig.node_id` into `Resource` so wal + output share it — too invasive, BREAKING the WAL config; (C) have `StreamConfig::build` inject `durability.node_id` into the output — requires a setter on the output trait and only works when durability is enabled.
+
+**Consequence:** the former `node_id` promotion task is dropped. The spec requirement becomes "explicit stable transactional identity", not "node_id at durability top-level".
+
+### D6 — SQL idempotent upsert is out of scope (separate change)
+
+**Discovery during apply:** the SQL output's metadata *advertises* `upsert`/`upsert_keys` (`output/sql.rs:449-450`), but the implementation does not support them — `SqlOutputConfig` has only `output_type` + `table_name`, and `DatabaseConnection::execute_insert` does plain INSERT (no `ON CONFLICT` / `ON DUPLICATE KEY`). The schema is aspirational and drifts from the implementation; `upsert: true` is silently ignored by serde.
+
+**Decision:** this change does not touch the SQL output. Real idempotent upsert (plus fixing the schema-vs-implementation drift) is a separate change. The earlier assumption "SQL L1 reuses existing upsert" was wrong — it was based on the metadata, not the struct.
+
+### D7 — Honest L2 boundary; L3 path recorded as future
+
+L2 covers: in-transaction atomicity, zombie fencing (`transactional.id` + read_committed downstream), same-instance dedup (idempotent producer PID). L2 does **not** cover the **already-committed-then-crash window**: if the producer commits the transaction but the process crashes before the source offset auto-commits, replay redelivers and a *new* producer (new PID) writes again — `read_committed` downstream sees both. This window is bounded by the auto-commit interval. Mitigations: downstream business idempotency / dedup key, or future L3.
+
+**L3 future path (Kafka→Kafka only):** `send_offsets_to_transaction(consumer.offset, consumer.group_metadata)` folds the source offset commit into the same producer transaction, eliminating the window. This requires reworking `KafkaAck` from `store_offset` to in-transaction offset commit and needs `ConsumerGroupMetadata`; out of scope here.
+
+## Risks / Trade-offs
+
+- **[commit_transaction blocks the async worker]** → wrap `init/commit/abort` in `spawn_blocking`. The `send_result` path stays async (delivery futures are awaited as today).
+- **[Large transactions when windows are big]** → transaction size is bounded by the buffer aggregation unit (D3); documented as a knob controlled by processor/window config, not a new mechanism.
+- **[Spike was source-level only; runtime behavior unverified in this repo]** → an integration test against a real broker (or testcontainers redpanda) is required in tasks, covering commit, abort, and the post-commit-crash duplicate window.
+- **[L2 post-commit-crash duplicate window]** → explicitly declared in specs as outside L2's guarantee; downstream idempotency or future L3 required. Not silently hidden.
+- **[`node_id` config move is BREAKING]** → migration plan below; `--validate` emits a clear error pointing to the new location.
+- **[Transactional producer cannot send outside a transaction once initialized]** → the Kafka output's transactional mode is opt-in; the default non-transactional `FutureProducer` path is preserved for users who don't enable EOS.
+
+## Migration Plan
+
+1. **`node_id` relocation**: accept `durability.node_id`. During a deprecation window, also read `durability.backend.object_store.node_id` with a warn-level deprecation log if the top-level is absent. `--validate` documents the move. After one release, drop the fallback.
+2. **`write_batch` default**: lands first as a pure refactor (default impl + `do_output` switch) with no output overriding it — provably zero behavior change via existing stream tests. Kafka/SQL overrides land as a follow-up within the same change.
+3. **Kafka transactional mode**: opt-in via `transactional.id` (explicit) or an `exactly_once: true` flag (derives the id). Default stays the current idempotent producer.
+4. **Rollback**: disabling `exactly_once` / removing `transactional.id` reverts Kafka to today's behavior; the `write_batch` refactor is internally reversible and carries no semantic risk.
+
+## Open Questions
+
+- **Auto-commit interval in EOS mode**: should `auto.commit.interval.ms` be tightened (or source commit made synchronous) to shrink the L2 post-commit duplicate window? Trade-off is throughput vs. duplicate exposure. Defer to implementation profiling.
+- **Default for Kafka `exactly_once`**: opt-in (explicit flag, safest) vs. on-when-`transactional.id`-present. Leaning opt-in; confirm during implementation.
+- **Integration test broker**: RESOLVED — use `confluentinc/cp-kafka:7.5.0` (KRaft single-node) via testcontainers, not redpanda. cp-kafka is the Kafka transaction reference implementation, is reliably pullable in CI (and was already cached on the dev machine), and redpanda is wire-compatible so the EOS semantics under test (atomic commit, zombie fencing, the post-commit duplicate window) are identical; `tasks.md` 3.1 explicitly permitted a broker fallback. A mock was rejected because it cannot validate fencing/atomicity. See `crates/arkflow-plugin/tests/kafka_eos.rs`.

--- a/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/proposal.md
+++ b/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+ArkFlow delivers **at-least-once** today. After a crash, in-flight messages are replayed and MAY be redelivered to outputs (`openspec/specs/input-durability/spec.md`, requirement "At-least-once delivery" → scenario "Duplicate delivery after recovery"). Two code-level facts widen the duplicate exposure:
+
+- The output worker writes messages **one-by-one, non-atomically** within an ack range (`crates/arkflow-core/src/stream/mod.rs:469-483`). A partial write failure leaves already-written rows to be duplicated on replay.
+- The Kafka source commits offsets **asynchronously** via `store_offset` + periodic auto-commit (`crates/arkflow-plugin/src/input/kafka.rs:285-294`), so the duplicate window extends to the auto-commit interval (default 5s), not just the crash instant.
+
+For duplicate-intolerant sinks (Kafka transactional, JDBC upsert) these duplicates yield wrong results and block enterprise production use. This is precisely Benthos's stated weak spot (stateless, no native EOS), and closing it is the core of direction ② (see `openspec/PLANNING.md` §1.3 "生态位" and §3.2 Change 3).
+
+## What Changes
+
+- **Add `Output::write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error>`** with a default implementation equivalent to today's per-message loop (zero behavior change for outputs that don't override it). One ack range = one `write_batch` call = one transaction unit.
+- **Refactor `do_output`** to call `write_batch` once per ack range instead of looping `write` in the stream layer (`stream/mod.rs:465-484`). The ordering logic (`BTreeMap` + `next_seq` watermark) and the ack chain (`WalAck` → `advance` → source commit) are untouched.
+- **Kafka output gains transactional production (L2)**: opt-in via `exactly_once: true` + explicit `transactional_id`; `init_transactions` + `begin/send/commit_transaction`. Confirmed feasible — rdkafka 0.38's async `FutureProducer` implements the full transactional `Producer` trait (`rdkafka-0.38.0/src/producer/future_producer.rs:388,410-434`).
+- **Kafka output gains explicit transactional config**: `exactly_once: true` + `transactional_id` (required when exactly_once is on). The user owns the id and keeps it stable across restarts. Decoupled from the WAL's `node_id` (different identity concepts) — no core or WAL config change, no migration.
+- **Honest EOS scope**: L2 (Kafka transactional) = *effectively-once*. L3 (true end-to-end via `send_offsets_to_transaction`, Kafka→Kafka only) is explicitly a non-goal.
+
+## Capabilities
+
+### New Capabilities
+
+- `exactly-once-output`: the transactional output contract (`write_batch` transaction unit), Kafka transactional-producer semantics, the transaction-boundary = buffer-aggregation-unit rule, and the honest effectively-once boundary (what L2 does and does not cover).
+
+### Modified Capabilities
+
+<!-- Exploration confirmed the Ack contract (message-acknowledgment) and the at-least-once
+     guarantee (input-durability) are UNCHANGED — EOS is layered on top via the new output
+     contract, not by extending ack with an epoch. This is simpler than PLANNING.md's initial
+     guess of modifying both. No delta specs needed. -->
+
+(none)
+
+## Non-goals
+
+- **L3 true end-to-end EOS** via `send_offsets_to_transaction` (Kafka→Kafka consume-transform-produce). It requires reworking `KafkaAck` to commit offsets inside the producer transaction with `ConsumerGroupMetadata`, and works only when both source and sink are Kafka. Tracked as a future extension in `design.md`.
+- **Stateful processor checkpoint/recovery** — that is Change 4 in the roadmap; depends on this change's ack chain but is separately scoped.
+- **Idempotent adapters for outputs other than Kafka and SQL** (Redis / Pulsar / NATS / MQTT / InfluxDB / HTTP / Stdout / Drop) — they keep today's default at-least-once behavior. Can be added incrementally later by overriding `write_batch`.
+- **Distributed / HA** — stays single-node, per direction ②'s explicit boundary against RisingWave/Arroyo territory.
+- **SQL idempotent upsert** — the SQL output's metadata *advertises* `upsert`/`upsert_keys`, but the implementation does not support them (`SqlOutputConfig` has only `output_type` + `table_name`; `execute_insert` does plain INSERT). Real `ON CONFLICT` / `ON DUPLICATE KEY` support — and fixing the schema-vs-implementation drift — is a separate change. This change does not touch the SQL output.
+- **Changing the `Ack` trait** — no epoch/sequence is added to ack. Transaction identity lives entirely in the output (explicit `transactional_id`), keeping the ack contract stable.
+
+## Impact
+
+- **arkflow-core**:
+  - `output/mod.rs` — `Output` trait gains the `write_batch` default method.
+  - `stream/mod.rs:401-486` — `do_output` / `output` rewritten to call `write_batch` once per ack range.
+- **arkflow-plugin**:
+  - `output/kafka.rs` — transactional producer path + `exactly_once`/`transactional_id` config (the bulk of the implementation work).
+  - The other 9 outputs — **unchanged** (inherit the `write_batch` default).
+- **Dependencies**: none new. rdkafka 0.38 already supports transactions under the `cmake-build` feature currently in use.
+- **Config**: optional `exactly_once` + `transactional_id` on the Kafka output. No core or WAL config change, no migration.

--- a/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/specs/exactly-once-output/spec.md
+++ b/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/specs/exactly-once-output/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Batched transaction-unit write contract
+The `Output` trait SHALL provide `write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error>`. The default implementation SHALL write each message via `write()` in order and return `Err` if any single write failed (continue-on-error, collecting the last error), preserving today's per-message behavior. The stream's output worker SHALL invoke `write_batch` exactly once per ack range instead of looping `write` in the stream layer.
+
+#### Scenario: Default implementation preserves per-message behavior
+- **WHEN** an output does not override `write_batch`
+- **THEN** its behavior is identical to today's per-message loop: every message is attempted, and the ack is triggered only when all writes succeed
+
+#### Scenario: Output worker calls write_batch once per ack range
+- **WHEN** the output worker processes a `ProcessorData::Ok` batch of N messages
+- **THEN** it calls `write_batch` exactly once with all N messages, not `write` N times
+
+#### Scenario: write_batch failure withholds the ack
+- **WHEN** `write_batch` returns `Err`
+- **THEN** the ack is not called, the WAL cursor does not advance, and the ack range is replayed on recovery
+
+### Requirement: Transaction boundary equals the buffer aggregation unit
+When a buffer (memory, tumbling/sliding/session window, or join) aggregates multiple input messages into one output batch, that batch's composite ack (e.g. `VecAck` / `ArrayAck`) SHALL be delivered to a single `write_batch` call. A transactional output SHALL treat one `write_batch` call as one atomic transaction unit covering all constituent input acks. No buffer SHALL drop, split, or silently merge acks in a way that breaks the one-`write_batch`-per-ack-range invariant.
+
+#### Scenario: Window aggregation is one transaction unit
+- **WHEN** a tumbling window aggregates messages from three input reads whose acks are combined into a single composite ack
+- **THEN** the aggregated batch is delivered to exactly one `write_batch` call, and a transactional sink commits the whole window atomically
+
+### Requirement: Kafka transactional output (L2)
+A Kafka output configured for exactly-once SHALL use a transactional producer: `init_transactions` at `connect()`, `begin_transaction` before sending, and `commit_transaction` after every message in the `write_batch` is sent. The blocking transaction calls (`init_transactions`, `commit_transaction`, `abort_transaction`) SHALL NOT run on the async worker. Downstream consumers with `isolation.level=read_committed` SHALL observe each `write_batch` atomically — all messages or none.
+
+#### Scenario: Multi-message atomic commit
+- **WHEN** `write_batch` receives multiple messages and the producer commits the transaction
+- **THEN** a `read_committed` downstream consumer observes all of them together, or none
+
+#### Scenario: In-transaction failure aborts and replays
+- **WHEN** `commit_transaction` fails with a `txn_requires_abort` error
+- **THEN** `abort_transaction` is called, `write_batch` returns `Err`, the ack is withheld, and the range is replayed on recovery
+
+#### Scenario: Zombie producer fenced across restart
+- **WHEN** the process restarts using the same `transactional.id`
+- **THEN** the broker fences the prior producer epoch and aborts that producer's in-flight transaction, so zombie writes are not visible to `read_committed` consumers
+
+### Requirement: Effectively-once boundary is honestly scoped
+The Kafka transactional output (L2) SHALL eliminate in-transaction partial writes and zombie duplicates. It SHALL NOT guarantee the absence of duplicates when a crash occurs after the producer transaction is committed and before the source offset is committed. Such residual duplicates MUST be absorbed by downstream idempotency (dedup key, business idempotency) or by a future L3 mechanism that commits the source offset inside the producer transaction. This limitation SHALL be documented.
+
+#### Scenario: Post-commit pre-offset-commit crash produces duplicates
+- **WHEN** the producer commits the transaction and the process crashes before the source offset is committed by auto-commit
+- **THEN** on recovery the source redelivers the range, a new producer writes it again, and a `read_committed` downstream consumer observes duplicate rows — which downstream idempotency MUST absorb
+
+### Requirement: Explicit stable transactional identity
+A Kafka output configured with `exactly_once: true` SHALL require a non-empty `transactional_id`. The `transactional_id` SHALL be stable across restarts (the user is responsible for this) and unique per stream producer, so the broker can fence prior producer epochs on restart. The WAL's `node_id` (object-store namespace) and the Kafka `transactional_id` SHALL remain independent configuration values — neither is derived from the other.
+
+#### Scenario: transactional_id required when exactly_once is enabled
+- **WHEN** a Kafka output is configured with `exactly_once: true` but no `transactional_id`
+- **THEN** configuration validation fails with a clear error
+
+#### Scenario: transactional_id stability is the user's responsibility
+- **WHEN** the process restarts and the user supplies the same `transactional_id`
+- **THEN** the broker fences the prior producer epoch and aborts its in-flight transaction
+
+#### Scenario: transactional_id is independent of WAL node_id
+- **WHEN** a stream uses the object-store WAL backend with its own `node_id` and a Kafka output with a separate `transactional_id`
+- **THEN** the two values are used independently — WAL namespace isolation and Kafka zombie fencing respectively

--- a/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/tasks.md
+++ b/openspec/changes/archive/2026-08-01-add-end-to-end-exactly-once/tasks.md
@@ -1,0 +1,27 @@
+## 1. Core trait refactor (zero behavior change)
+
+- [x] 1.1 Add `write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error>` default method to the `Output` trait in `crates/arkflow-core/src/output/mod.rs` (continue-on-error, collecting last error). — verify: `cargo build -p arkflow-core`
+- [x] 1.2 Rewrite `Stream::do_output` / `output` (`crates/arkflow-core/src/stream/mod.rs:401-486`) to call `write_batch` once per ack range; the err_output path uses `write_batch(&[msg])`. Ordering (`BTreeMap` + `next_seq`) and ack chain stay untouched. — verify: `cargo test -p arkflow-core`
+- [x] 1.3 Add a unit test asserting the output worker calls `write_batch` exactly once per ack range (not N times `write`). — verify: `cargo test -p arkflow-core stream`
+- [x] 1.4 Add a unit test asserting a `write_batch` `Err` withholds the ack (WAL cursor does not advance). — verify: `cargo test -p arkflow-core`
+
+## 2. Kafka transactional output (L2)
+
+- [x] 2.1 Add `exactly_once: bool` (default false) and `transactional_id: Option<String>` to the Kafka output config; `OutputBuilder::build` SHALL reject `exactly_once: true` without a non-empty `transactional_id`. — verify: `cargo test -p arkflow-plugin kafka`
+- [x] 2.2 When `exactly_once` is on, create a `FutureProducer` with `transactional.id` + `enable.idempotence` set and call `init_transactions` at `connect()` (in `spawn_blocking`). When off, keep today's non-transactional producer. — verify: `cargo build -p arkflow-plugin`
+- [x] 2.3 Override `write_batch` for the transactional path: `begin_transaction → send_result × N → commit_transaction`, with the blocking transaction calls inside `spawn_blocking`. — verify: `cargo build -p arkflow-plugin`
+- [x] 2.4 Map rdkafka transaction errors to the three states: `is_retriable` → retry the op, `txn_requires_abort` → `abort_transaction` then re-begin, `is_fatal` → propagate (producer discarded). — verify: `cargo clippy -p arkflow-plugin`
+- [x] 2.5 Preserve the non-transactional default path; existing Kafka output behavior is unchanged when `exactly_once` is off (its `write_batch` falls through to the default). — verify: existing kafka output unit test passes
+
+## 3. Integration tests
+
+- [x] 3.1 Add a testcontainers broker fixture for Kafka transaction tests (`tests/kafka_eos.rs`). Uses `confluentinc/cp-kafka:7.5.0` (KRaft single-node) instead of redpanda: cp-kafka is the Kafka transaction reference implementation, is reliably pullable in CI, and redpanda is wire-compatible so the EOS semantics under test are identical (the redpanda-vs-mock fallback was explicitly permitted). — verify: `cargo test -p arkflow-plugin --test kafka_eos --no-run`
+- [x] 3.2 Multi-message atomic commit: a `read_committed` consumer observes all messages of a `write_batch`. — verify: `cargo test -p arkflow-plugin --test kafka_eos atomic_commit`
+- [x] 3.3 Zombie fencing across a simulated restart (same `transactional_id`). — verify: `cargo test -p arkflow-plugin --test kafka_eos zombie_fenced`
+- [x] 3.4 The L2 post-commit boundary: crash after producer commit but before source offset commit yields duplicates (documents the honest L2 scope). — verify: `cargo test -p arkflow-plugin --test kafka_eos post_commit`
+
+## 4. Docs, examples, wrap-up
+
+- [x] 4.1 Add an example config `examples/eos-kafka.yaml` (Kafka input → Kafka transactional output with `exactly_once: true` + `transactional_id`). — verify: `--validate`
+- [x] 4.2 Update CLAUDE.md "Codec Components" / output sections to note Kafka transactional EOS support. — verify: doc review
+- [x] 4.3 Update `openspec/PLANNING.md` progress table: Change 3 EOS status + decision note. — verify: manual

--- a/openspec/specs/async-codec-contract/spec.md
+++ b/openspec/specs/async-codec-contract/spec.md
@@ -1,0 +1,16 @@
+# async-codec-contract Specification
+
+## Purpose
+TBD - created by archiving change refactor-codec-async. Update Purpose after archive.
+## Requirements
+### Requirement: Codec 编解码为异步
+`Encoder`/`Decoder`（及 `Codec`）trait 的 `encode`/`decode` 方法 SHALL 为 `async`，使 codec 实现可在方法体内执行异步 IO。现有 json/protobuf/debezium codec 的编解码行为与语义 SHALL 保持不变。
+
+#### Scenario: 现有 codec 行为不变
+- **WHEN** json/protobuf/debezium codec 经 async `encode`/`decode` 调用
+- **THEN** 输入输出与重构前（sync）完全一致（现有 round-trip 与单元测试全绿）
+
+#### Scenario: codec 实现可执行异步 IO
+- **WHEN** 一个 codec 的 `decode` 需要异步操作（如 HTTP 查询外部服务）
+- **THEN** 可在 async `decode` 内 `.await` 该操作，不阻塞 tokio runtime
+

--- a/openspec/specs/debezium-cdc-parsing/spec.md
+++ b/openspec/specs/debezium-cdc-parsing/spec.md
@@ -1,0 +1,71 @@
+# debezium-cdc-parsing Specification
+
+## Purpose
+TBD - created by archiving change add-cdc-debezium. Update Purpose after archive.
+## Requirements
+### Requirement: Debezium Envelope 解析为列式 Arrow
+`debezium_json` codec 收到 Debezium Envelope JSON（含 `before`/`after`/`op`/`source`/`ts_ms`）时，SHALL 输出列式 `MessageBatch`：`after` 的字段扁平化为顶层列（主数据行），并附加 `before`（作为 JSON 文本列）、`op`、`ts_ms` 与 `source` 元信息列。
+
+#### Scenario: create 事件
+- **WHEN** codec 解析一条 `op="c"` 的 Envelope（`after` 含新行数据，`before` 为 null）
+- **THEN** 输出 `MessageBatch` 的顶层列为 `after` 的字段值，`op` 列为 `"c"`，`before` 列为 null
+
+#### Scenario: update 事件
+- **WHEN** codec 解析一条 `op="u"` 的 Envelope（`before` 与 `after` 均非空）
+- **THEN** 顶层列为 `after` 的新值，`before` JSON 文本列保留变更前值，`op` 列为 `"u"`
+
+#### Scenario: delete 事件
+- **WHEN** codec 解析一条 `op="d"` 的 Envelope（`after` 为 null，`before` 含被删行数据）
+- **THEN** 顶层列取自 `before` 的字段值，`op` 列为 `"d"`，下游可据此识别删除
+
+#### Scenario: snapshot/read 事件
+- **WHEN** codec 解析一条 `op="r"` 的 Envelope（初始快照行）
+- **THEN** 顶层列为 `after` 的初始值，`op` 列为 `"r"`
+
+### Requirement: 操作类型列 op
+codec SHALL 在每条输出中附加顶层 `op` 列，其值为该 Envelope 的 `op` 字段原值（`c`/`u`/`d`/`r` 之一）。
+
+#### Scenario: op 值透传
+- **WHEN** Envelope 的 `op` 为 `"u"`
+- **THEN** 输出 `op` 列对应行为 `"u"`
+
+### Requirement: 源元信息列
+codec SHALL 附加 `source` 关键字段为顶层列（至少 `source_db`、`source_table`），保留完整 `source` 对象为 JSON 文本列（供下游 SQL 用 JSON 函数查询），并附加 `ts_ms` 为顶层列。`before` 同样以 JSON 文本列保留完整变更前值。
+
+#### Scenario: source 字段提取
+- **WHEN** Envelope 的 `source` 含 `db="orders"`、`table="orders"`
+- **THEN** 输出含顶层列 `source_db="orders"`、`source_table="orders"`，且完整 `source` JSON 文本列保留全部源字段
+
+#### Scenario: ts_ms 透传
+- **WHEN** Envelope 含 `ts_ms=1700000000000`
+- **THEN** 输出 `ts_ms` 顶层列为 `1700000000000`
+
+### Requirement: 字段缺失容错
+当 Envelope 的 `before`、`after` 或 `source` 缺失或为 null 时，codec SHALL 以 null 填充对应列，不得返回错误。
+
+#### Scenario: delete 时 after 为 null
+- **WHEN** 一条 `op="d"` 的 Envelope 的 `after` 为 null
+- **THEN** codec 正常输出，顶层业务列取自 `before`，未涉及的列以 null 填充，不报错
+
+#### Scenario: source 缺失
+- **WHEN** 一条 Envelope 不含 `source` 字段
+- **THEN** `source_db`/`source_table` 顶层列为 null，`source`/`before` JSON 文本列保留为 `"null"` 文本，codec 不报错
+
+### Requirement: 作为 codec 注册并经 Kafka input 接入
+`debezium_json` codec SHALL 经 `register_codec_builder` 注册，并可被 Kafka input 通过现有 codec 接入点（`apply_codec_to_payload`）调用，无需新增 input 类型或修改 input 代码。
+
+#### Scenario: Kafka input 配置 debezium_json codec
+- **WHEN** 一个 Kafka input 配置 `codec: { type: "debezium_json" }` 并读到一条 Debezium Envelope 字节
+- **THEN** input 输出的 `MessageBatch` 为该 Envelope 解析后的列式数据（含 `op`/业务列/`before`/`source_*`）
+
+#### Scenario: 未配置 codec 时行为不变
+- **WHEN** Kafka input 未配置 codec
+- **THEN** 其行为与现状完全一致，不受本 codec 存在的影响
+
+### Requirement: CDC 位点复用 ack-gated Kafka offset
+codec SHALL NOT 引入自身的位点/offset 管理；CDC 位点由 Kafka input 现有的 ack-gated offset 承担（消费位点经 `input-durability` 的 ack-gated source-commit 推进）。
+
+#### Scenario: 位点推进与 input-durability 一致
+- **WHEN** 下游确认写入、Kafka input 的 ack 被触发
+- **THEN** Kafka offset 按 `input-durability` 现有语义推进，codec 不参与位点逻辑
+

--- a/openspec/specs/exactly-once-output/spec.md
+++ b/openspec/specs/exactly-once-output/spec.md
@@ -1,0 +1,64 @@
+# exactly-once-output Specification
+
+## Purpose
+TBD - created by archiving change add-end-to-end-exactly-once. Update Purpose after archive.
+## Requirements
+### Requirement: Batched transaction-unit write contract
+The `Output` trait SHALL provide `write_batch(&self, msgs: &[MessageBatchRef]) -> Result<(), Error>`. The default implementation SHALL write each message via `write()` in order and return `Err` if any single write failed (continue-on-error, collecting the last error), preserving today's per-message behavior. The stream's output worker SHALL invoke `write_batch` exactly once per ack range instead of looping `write` in the stream layer.
+
+#### Scenario: Default implementation preserves per-message behavior
+- **WHEN** an output does not override `write_batch`
+- **THEN** its behavior is identical to today's per-message loop: every message is attempted, and the ack is triggered only when all writes succeed
+
+#### Scenario: Output worker calls write_batch once per ack range
+- **WHEN** the output worker processes a `ProcessorData::Ok` batch of N messages
+- **THEN** it calls `write_batch` exactly once with all N messages, not `write` N times
+
+#### Scenario: write_batch failure withholds the ack
+- **WHEN** `write_batch` returns `Err`
+- **THEN** the ack is not called, the WAL cursor does not advance, and the ack range is replayed on recovery
+
+### Requirement: Transaction boundary equals the buffer aggregation unit
+When a buffer (memory, tumbling/sliding/session window, or join) aggregates multiple input messages into one output batch, that batch's composite ack (e.g. `VecAck` / `ArrayAck`) SHALL be delivered to a single `write_batch` call. A transactional output SHALL treat one `write_batch` call as one atomic transaction unit covering all constituent input acks. No buffer SHALL drop, split, or silently merge acks in a way that breaks the one-`write_batch`-per-ack-range invariant.
+
+#### Scenario: Window aggregation is one transaction unit
+- **WHEN** a tumbling window aggregates messages from three input reads whose acks are combined into a single composite ack
+- **THEN** the aggregated batch is delivered to exactly one `write_batch` call, and a transactional sink commits the whole window atomically
+
+### Requirement: Kafka transactional output (L2)
+A Kafka output configured for exactly-once SHALL use a transactional producer: `init_transactions` at `connect()`, `begin_transaction` before sending, and `commit_transaction` after every message in the `write_batch` is sent. The blocking transaction calls (`init_transactions`, `commit_transaction`, `abort_transaction`) SHALL NOT run on the async worker. Downstream consumers with `isolation.level=read_committed` SHALL observe each `write_batch` atomically — all messages or none.
+
+#### Scenario: Multi-message atomic commit
+- **WHEN** `write_batch` receives multiple messages and the producer commits the transaction
+- **THEN** a `read_committed` downstream consumer observes all of them together, or none
+
+#### Scenario: In-transaction failure aborts and replays
+- **WHEN** `commit_transaction` fails with a `txn_requires_abort` error
+- **THEN** `abort_transaction` is called, `write_batch` returns `Err`, the ack is withheld, and the range is replayed on recovery
+
+#### Scenario: Zombie producer fenced across restart
+- **WHEN** the process restarts using the same `transactional.id`
+- **THEN** the broker fences the prior producer epoch and aborts that producer's in-flight transaction, so zombie writes are not visible to `read_committed` consumers
+
+### Requirement: Effectively-once boundary is honestly scoped
+The Kafka transactional output (L2) SHALL eliminate in-transaction partial writes and zombie duplicates. It SHALL NOT guarantee the absence of duplicates when a crash occurs after the producer transaction is committed and before the source offset is committed. Such residual duplicates MUST be absorbed by downstream idempotency (dedup key, business idempotency) or by a future L3 mechanism that commits the source offset inside the producer transaction. This limitation SHALL be documented.
+
+#### Scenario: Post-commit pre-offset-commit crash produces duplicates
+- **WHEN** the producer commits the transaction and the process crashes before the source offset is committed by auto-commit
+- **THEN** on recovery the source redelivers the range, a new producer writes it again, and a `read_committed` downstream consumer observes duplicate rows — which downstream idempotency MUST absorb
+
+### Requirement: Explicit stable transactional identity
+A Kafka output configured with `exactly_once: true` SHALL require a non-empty `transactional_id`. The `transactional_id` SHALL be stable across restarts (the user is responsible for this) and unique per stream producer, so the broker can fence prior producer epochs on restart. The WAL's `node_id` (object-store namespace) and the Kafka `transactional_id` SHALL remain independent configuration values — neither is derived from the other.
+
+#### Scenario: transactional_id required when exactly_once is enabled
+- **WHEN** a Kafka output is configured with `exactly_once: true` but no `transactional_id`
+- **THEN** configuration validation fails with a clear error
+
+#### Scenario: transactional_id stability is the user's responsibility
+- **WHEN** the process restarts and the user supplies the same `transactional_id`
+- **THEN** the broker fences the prior producer epoch and aborts its in-flight transaction
+
+#### Scenario: transactional_id is independent of WAL node_id
+- **WHEN** a stream uses the object-store WAL backend with its own `node_id` and a Kafka output with a separate `transactional_id`
+- **THEN** the two values are used independently — WAL namespace isolation and Kafka zombie fencing respectively
+

--- a/openspec/specs/schema-registry-integration/spec.md
+++ b/openspec/specs/schema-registry-integration/spec.md
@@ -1,0 +1,59 @@
+# schema-registry-integration Specification
+
+## Purpose
+TBD - created by archiving change add-schema-registry. Update Purpose after archive.
+## Requirements
+### Requirement: Confluent wire format 解析
+`schema_registry` codec 收到消息字节时，SHALL 按 Confluent wire format 解析：首字节为 magic（MUST 为 `0x00`），随后 4 字节为大端 schema id，其余为 payload。magic 不为 `0x00` 或消息短于 5 字节时 SHALL 返回错误。
+
+#### Scenario: 有效 wire format
+- **WHEN** codec 收到 `0x00 0x00 0x00 0x00 0x01 <payload>`
+- **THEN** 剥出 schema id=1 与 payload，进入按 id 解码
+
+#### Scenario: magic byte 非法
+- **WHEN** 消息首字节不为 `0x00`
+- **THEN** codec 返回错误，不尝试解码
+
+#### Scenario: 消息过短
+- **WHEN** 消息不足 5 字节
+- **THEN** codec 返回错误
+
+### Requirement: 按 schema id 从 Schema Registry 获取 schema
+codec SHALL 经 Schema Registry（Confluent REST：`GET {registry}/schemas/ids/{id}`）按 schema id 获取 Protobuf schema，并构建 `MessageDescriptor` 解码 payload。registry 返回错误（非 200 或连接失败）时 SHALL 返回错误。
+
+#### Scenario: 首次拉取 schema
+- **WHEN** codec 遇到一个未缓存的 schema id
+- **THEN** 向 registry 请求 schema，构建 descriptor 解码 payload
+
+#### Scenario: registry 不可达
+- **WHEN** registry 返回非 200 或连接失败
+- **THEN** codec 返回错误，不静默跳过
+
+### Requirement: 按 schema id 缓存 descriptor
+codec SHALL 按 schema id 缓存已构建的 `MessageDescriptor`，使同一 id 的后续消息不再发起 registry 请求。
+
+#### Scenario: 重复 id 命中缓存
+- **WHEN** codec 连续遇到同一 schema id 的多条消息
+- **THEN** 仅首次发起 registry 请求，后续命中缓存解码
+
+### Requirement: 多版本 schema 解码
+codec SHALL 支持同一流中不同 schema id（不同 schema 版本）的消息，各自用对应版本的 descriptor 解码。
+
+#### Scenario: 同 batch 多版本
+- **WHEN** 一个 batch 含 schema id=1 与 schema id=2 的消息（两版 schema）
+- **THEN** 各自用对应 descriptor 解码，不互相干扰
+
+### Requirement: 作为 codec 注册并可配置
+`schema_registry` codec SHALL 经 `register_codec_builder` 注册，配置至少含 registry URL 与 message type；可经 input/output 的 codec 接入点使用。
+
+#### Scenario: 配置 codec
+- **WHEN** 一个 input 配置 `codec: { type: "schema_registry", registry_url: "...", message_type: "..." }`
+- **THEN** codec 按 registry 解码消息，未配置时现有 codec 行为不受影响
+
+### Requirement: 可选认证
+codec SHALL 支持可选的 registry 认证（Basic auth 或 bearer token），经配置提供。
+
+#### Scenario: 配置 Basic auth
+- **WHEN** codec 配置含 `auth: { type: "basic", username, password }`
+- **THEN** registry 请求携带 Basic Authorization 头
+


### PR DESCRIPTION
## 方向②：生产级端到端可靠性（Change 1-3 of `openspec/PLANNING.md`）

Three changes from the reliability roadmap, layered on the existing input-WAL (at-least-once) foundation.

### Change 1 — CDC Input (Debezium)
- `debezium_json` codec; reuses Kafka input + ack-gated offset as the source-side commit point.
- spec: `debezium-cdc-parsing`

### Refactor — Codec trait async
- Codec trait async-ified (pure refactor, no behavior change); unblocks reqwest-based async codecs.
- spec: `async-codec-contract`

### Change 2 — Schema Registry
- Confluent/Apicurio registry via reqwest async `SchemaResolver`; per-id cache, multi-version; auth HTTP mock tests (wiremock).
- spec: `schema-registry-integration`

### Change 3 — End-to-end Exactly-Once (L2)
- `Output::write_batch` default method (1 ack range = 1 transaction unit; default impl preserves per-message behavior — non-EOS outputs unchanged).
- Kafka output opt-in transactional producer (`exactly_once` + explicit `transactional_id`); init/begin/send/commit, blocking calls off the async worker, rdkafka three-state error mapping; honest L2 boundary.
- testcontainers integration tests (cp-kafka KRaft): smoke, atomic commit, zombie fencing, post-commit duplicate window.
- spec: `exactly-once-output`

### Notes
- All changes follow OpenSpec `propose → apply → verify → archive`; specs merged into `openspec/specs/`. Roadmap in `openspec/PLANNING.md`.
- EOS test broker is `confluentinc/cp-kafka` (KRaft) not redpanda: Kafka transaction reference impl, reliably pullable in CI, wire-compatible — semantics identical (tasks 3.1 permitted the fallback).

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Debezium JSON CDC decoding with flattened event data and metadata.
  * Added Confluent Schema Registry support for Protobuf messages, schema evolution, caching, and optional authentication.
  * Added opt-in exactly-once Kafka output with transactional batch processing.
  * Added example configurations for CDC, Schema Registry, and exactly-once Kafka workflows.

* **Improvements**
  * Codec operations now support asynchronous processing.
  * Outputs process acknowledgment ranges as batches for improved delivery handling.

* **Documentation**
  * Added configuration guidance and integration documentation for these features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->