### PR TITLE
refactor(stream): replace backpressure sleep-polling with Notify signal

### DIFF
--- a/crates/arkflow-core/src/stream/mod.rs
+++ b/crates/arkflow-core/src/stream/mod.rs
@@ -28,6 +28,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{error, info};
@@ -46,6 +47,10 @@ pub struct Stream {
     resource: Resource,
     sequence_counter: Arc<AtomicU64>,
     next_seq: Arc<AtomicU64>,
+    /// Signaled by `do_output` each time it advances `next_seq`, so a
+    /// `do_processor` worker blocked on backpressure wakes immediately
+    /// instead of sleep-polling.
+    next_seq_notify: Arc<Notify>,
 }
 
 enum ProcessorData {
@@ -76,6 +81,7 @@ impl Stream {
             thread_num,
             sequence_counter: Arc::new(AtomicU64::new(0)),
             next_seq: Arc::new(AtomicU64::new(0)),
+            next_seq_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -141,6 +147,7 @@ impl Stream {
                 output_sender.clone(),
                 self.sequence_counter.clone(),
                 self.next_seq.clone(),
+                self.next_seq_notify.clone(),
             ));
         }
 
@@ -150,6 +157,7 @@ impl Stream {
 
         tracker.spawn(Self::do_output(
             self.next_seq.clone(),
+            self.next_seq_notify.clone(),
             output_receiver,
             self.output.clone(),
             self.error_output.clone(),
@@ -336,21 +344,23 @@ impl Stream {
         output_sender: Sender<(ProcessorData, Arc<dyn Ack>, u64)>,
         sequence_counter: Arc<AtomicU64>,
         next_seq: Arc<AtomicU64>,
+        next_seq_notify: Arc<Notify>,
     ) {
         let i = i + 1;
         info!("Processor worker {} started", i);
         loop {
-            // Backpressure control
+            // Backpressure: wait until the output drains enough in-flight
+            // messages. Take the notified() future BEFORE checking `pending`
+            // so a notify_one() issued between the check and the await is not
+            // lost (it stores a permit the await then consumes).
+            let notified = next_seq_notify.notified();
             let pending_messages =
                 sequence_counter.load(Ordering::Acquire) - next_seq.load(Ordering::Acquire);
             if pending_messages > BACKPRESSURE_THRESHOLD {
-                let wait_time = std::cmp::min(
-                    500,
-                    100 + (pending_messages - BACKPRESSURE_THRESHOLD) / 100 * 10,
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(wait_time)).await;
+                notified.await;
                 continue;
             }
+            drop(notified);
 
             let Ok((msg, ack)) = input_receiver.recv_async().await else {
                 break;
@@ -400,6 +410,7 @@ impl Stream {
 
     async fn do_output(
         next_seq: Arc<AtomicU64>,
+        next_seq_notify: Arc<Notify>,
         output_receiver: Receiver<(ProcessorData, Arc<dyn Ack>, u64)>,
         output: Arc<dyn Output>,
         err_output: Option<Arc<dyn Output>>,
@@ -431,6 +442,7 @@ impl Stream {
 
                 Self::output(data, &ack, &output, err_output.as_ref()).await;
                 next_seq.fetch_add(1, Ordering::Release);
+                next_seq_notify.notify_one();
             }
         }
 
@@ -1271,6 +1283,116 @@ mod tests {
         );
 
         wal.close().await.unwrap();
+    }
+
+    /// Under backpressure (in-flight > `BACKPRESSURE_THRESHOLD`) the processor
+    /// worker MUST wait on the `next_seq_notify` signal instead of consuming
+    /// input; once `next_seq` advances and the signal fires, it resumes and
+    /// emits the processed batch. Closing the input while it is still blocked
+    /// MUST let it observe EOF and exit (no deadlock). Covers the in-flight
+    /// bound, signal-driven release, and liveness requirements.
+    #[tokio::test]
+    async fn processor_worker_waits_on_notify_under_backpressure() {
+        // In-flight is already 2× the threshold.
+        let sequence_counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(2 * BACKPRESSURE_THRESHOLD));
+        let next_seq: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let notify: Arc<Notify> = Arc::new(Notify::new());
+        let pipeline: Arc<Pipeline> = Arc::new(Pipeline::new(vec![]));
+        let (input_tx, input_rx) =
+            flume::bounded::<(MessageBatchRef, Arc<dyn crate::input::Ack>)>(4);
+        let (output_tx, output_rx) =
+            flume::bounded::<(ProcessorData, Arc<dyn crate::input::Ack>, u64)>(4);
+
+        // Stage one input message; under backpressure it MUST stay unconsumed.
+        input_tx
+            .send_async((
+                Arc::new(sample_batch()) as MessageBatchRef,
+                Arc::new(NoopAck) as Arc<dyn crate::input::Ack>,
+            ))
+            .await
+            .unwrap();
+
+        let next_seq_task = next_seq.clone();
+        let notify_task = notify.clone();
+        let worker = tokio::spawn(async move {
+            Stream::do_processor(
+                0,
+                pipeline,
+                input_rx,
+                output_tx,
+                sequence_counter,
+                next_seq,
+                notify,
+            )
+            .await
+        });
+
+        // Let the worker reach the backpressure await.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            output_rx.is_empty(),
+            "processor must not emit while in-flight exceeds the threshold"
+        );
+
+        // Drain in-flight below the threshold and fire the signal.
+        next_seq_task.store(2 * BACKPRESSURE_THRESHOLD, Ordering::Release);
+        notify_task.notify_one();
+
+        let recv = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            output_rx.recv_async(),
+        )
+        .await
+        .expect("processor did not resume within timeout after notify")
+        .unwrap();
+        match recv.0 {
+            ProcessorData::Ok(_) => {}
+            _ => panic!("expected ProcessorData::Ok after resume"),
+        }
+
+        // Closing the input lets the worker observe EOF and exit — a blocked
+        // processor must not strand the shutdown.
+        drop(input_tx);
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), worker)
+            .await
+            .expect("processor worker did not exit after input EOF");
+    }
+
+    /// `do_output` SHALL fire `next_seq_notify` each time it advances `next_seq`
+    /// on an in-order write. Feeding seq=0 (== next_seq) drives one write, one
+    /// advance, and one notify.
+    #[tokio::test]
+    async fn output_worker_notifies_on_next_seq_advance() {
+        let next_seq: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let notify: Arc<Notify> = Arc::new(Notify::new());
+        let output: Arc<dyn Output> = Arc::new(CountingOutput::new());
+        let (output_tx, output_rx) =
+            flume::bounded::<(ProcessorData, Arc<dyn crate::input::Ack>, u64)>(4);
+
+        output_tx
+            .send_async((
+                ProcessorData::Ok(vec![Arc::new(sample_batch()) as MessageBatchRef]),
+                Arc::new(CountingAck(std::sync::atomic::AtomicBool::new(false)))
+                    as Arc<dyn crate::input::Ack>,
+                0,
+            ))
+            .await
+            .unwrap();
+        drop(output_tx);
+
+        let next_seq_check = next_seq.clone();
+        let notify_check = notify.clone();
+        tokio::spawn(async move {
+            Stream::do_output(next_seq, notify, output_rx, output, None).await
+        });
+
+        // do_output writes seq=0, advances next_seq to 1, fires notify_one.
+        notify_check.notified().await;
+        assert_eq!(
+            next_seq_check.load(Ordering::Acquire),
+            1,
+            "next_seq must advance after the in-order write"
+        );
     }
 }
 

--- a/openspec/changes/redesign-backpressure-notify/.openspec.yaml
+++ b/openspec/changes/redesign-backpressure-notify/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/redesign-backpressure-notify/design.md
+++ b/openspec/changes/redesign-backpressure-notify/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Stream 的数据流为 `Input → [Buffer] → do_processor (× thread_num) → do_output`。为支持**按序输出**，多个 processor worker 并发处理、各自用 `sequence_counter.fetch_add` 领号，`do_output` 用 `BTreeMap<seq, _>` + `next_seq` 重排出序的消息（`crates/arkflow-core/src/stream/mod.rs:407-434`）。
+
+为防止「已分配 seq 但尚未按序写出」的 in-flight 无界增长（会让 `tree_map` 与内存/WAL 失控），`do_processor` 在每次读取下一条输入前检查 `pending = sequence_counter - next_seq`，超过 `BACKPRESSURE_THRESHOLD = 1024`（`crates/arkflow-core/src/stream/mod.rs:35`）就让该 worker 暂停。**问题不在这个阈值语义，而在感知 `next_seq` 推进的方式**：当前是 `load` 两个原子量后 `tokio::time::sleep(100–500ms)` 再 `continue`（`crates/arkflow-core/src/stream/mod.rs:342-353`），而 `next_seq` 的推进发生在 `do_output`（`crates/arkflow-core/src/stream/mod.rs:433`）。processor 在「等 output 把 in-flight 排空」（即 drain），却靠周期性睡眠去发现 output 的进展。
+
+`do_output` 与 s3 WAL flusher 都已是事件/信号驱动（`crates/arkflow-plugin/src/wal/s3.rs:1080-1103` 用 `Notify`）；`do_processor` 的 backpressure 是仓库里**唯一**的 atomic 轮询点。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 把 backpressure 的「感知 output 推进」从 `sleep` 轮询改为显式信号，使解除即时（无 100–500ms 等待）。
+- 形式化 backpressure 的可观测契约（in-flight 有界、解除即时、关闭/取消无死锁），并补回归测试（当前为 0）。
+- 外科手术式改动：只动 `Stream` 的 backpressure 感知路径，不改阈值、不改顺序重排、不引新依赖。
+
+**Non-Goals:**
+
+- 不改 `BACKPRESSURE_THRESHOLD` 的值，也不把它可配置化。
+- 不改 `do_output` 的顺序重排逻辑、不改 in-flight 上界的语义。
+- 不重写 input 侧重连退避（`do_input` 的 `sleep(5s)`，`:271`，属于断连重试而非 drain）。
+- 不把 backpressure 改为「纯 channel 容量驱动」（移除 pending-count）——这是更彻底的后续重构，不在本次范围。
+
+## Decisions
+
+### Decision 1：信号原语用 `tokio::sync::Notify`
+
+新增 `next_seq_notify: Arc<Notify>`，由 `do_output` 在推进 `next_seq` 后 `notify_one()`，由 `do_processor` 在 backpressure 时 `notified().await`。
+
+**为什么不 `watch::channel`：** `watch` 基于 version 比较、天然不丢更新，语义上更贴合「等一个共享值变化」。但 `next_seq` 已是 `AtomicU64`（`do_output` 用 `fetch_add`、`do_processor` 用 `load`），引入 `watch` 等于给同一个值维护**第二份表示**并需时刻保持同步，改动更大。`Notify` 只承担「铃铛」职责，不触碰 `next_seq` 的存储，满足 surgical-change 原则。`watch` 列为备选（见 Risks）。
+
+**为什么不 `Semaphore`/`mpsc`：** 信号语义是「值变化了，去 re-check」，不是「获取许可」或「传消息」，`Notify` 最直接。
+
+### Decision 2：触发点 = `do_output` 每次推进 `next_seq` 后 `notify_one()`
+
+在 `:433` 的 `next_seq.fetch_add(1, Release)` 之后立即 `next_seq_notify.notify_one()`。逐条推进逐条通知，不做「跨阈值才通知」之类的聚合——聚合会重新引入延迟。
+
+用 `notify_one` 而非 `notify_waiters`：backpressure 的释放语义是「output 每按序写出一条 → `next_seq` +1 → 释放**一格** in-flight 额度」，正好对应唤醒**一个**等待中的 processor 去消费这一格；`notify_waiters` 会一次唤醒所有等待者（thundering herd），多数因额度仍不足 re-check 后回去再等。更关键的是 `notify_one()` 在无 waiter 时会**存一个 permit**（`notify_waiters` 不存），因此即便 processor 的 `notified()` future 尚未 poll 注册，permit 也会保留到它的首次 `await`——**不丢信号**（见 Decision 3）。
+
+### Decision 3：等待模式 = check-then-await
+
+`notify_one` 存 permit、本身不丢信号；但等待顺序仍采用「先取 future、再判条件、最后 await」，以收紧「判定 → 注册」窗口、避免无谓阻塞：
+
+```rust
+loop {
+    let notified = next_seq_notify.notified();        // 1. 先取 future
+    let pending = sequence_counter.load(Acquire)
+        - next_seq.load(Acquire);                     // 2. 再判条件
+    if pending > BACKPRESSURE_THRESHOLD {
+        notified.await;                               // 3. 超阈值才等
+        continue;                                     //    醒来后 re-check
+    }
+    drop(notified);
+    let Ok((msg, ack)) = input_receiver.recv_async().await else { break; };
+    // ... 处理（fetch_add sequence_counter）
+}
+```
+
+两点理由：(1) 先 `notified()` 再 `load`，确保「判完到 `await`」之间若有 `notify_one`，其 permit 能被随后的 `await` 消费，不漏掉推进；(2) 只在 `pending > THRESHOLD` 时 `await`，否则 `drop(notified)` 释放可能持有的 permit 并回到 `recv_async`，避免在 in-flight 已降下时无谓阻塞。
+
+### Decision 4：信号生命周期 = `Stream` 字段
+
+`next_seq_notify` 作为 `Stream` 字段、在 `Stream::new` 里初始化、在 `run_inner` 里 `clone` 下发给各 worker，与既有的 `sequence_counter` / `next_seq` 字段保持同一风格（`crates/arkflow-core/src/stream/mod.rs:47-48,77-78`）。不做成 `run_inner` 局部变量，以免与这两个兄弟字段分列两处。
+
+### Decision 5：无死锁活跃性论证
+
+backpressure 等待的唯一新风险是「processor 卡在 `notified().await` 无人唤醒」。证明其不发生：
+
+- `pending > THRESHOLD` ⟹ `sequence_counter - next_seq > 1024` ⟹ 尚有 >1024 条已领号消息未按序写出 ⟹ 它们要么在 `output_sender` 通道里、要么在 `do_output` 的 `tree_map` 里 ⟹ `do_output` **必然还有消息要处理**，会继续按序写出并 `fetch_add(next_seq)` + `notify_one()`。
+- 故只要 `pending > THRESHOLD`，`do_output` 必会再次发信号，processor 必被唤醒。反之 processor 醒来时若 `pending ≤ THRESHOLD`，本就不该继续等。
+
+输入 EOF / 取消场景同理：`do_input` 退出 → `input_sender` drop；`do_output` 持续排空剩余 in-flight，每排出一条即推进 `next_seq` 并通知，processor 逐次被唤醒；待 `pending` 降到阈值以下，processor 回到 `recv_async` 拿到 `None` 退出，`output_sender` 全部 clone 释放后 `do_output` 排出 `tree_map` 残留并退出。**比现状更快**：现状每个 processor 要等下一个 `sleep` 周期（最多 500ms）才感知推进，信号版是即时唤醒。
+
+## Risks / Trade-offs
+
+- **[关闭时 processor 卡在 `notified().await`]** → 由 Decision 5 的 EOF 论证覆盖：`do_output` 排空剩余 in-flight 的过程会持续 `notify_one()`。无新增超时/兜底，因为论证已闭合（且现状的 `sleep` 版同样依赖 output 排空、只是更慢）。
+- **[多余 permit / spurious wakeup]** `notify_one()` 在无 waiter 时存的 permit，可能让 processor 在 `pending` 已降到阈值以下时仍被立即唤醒一次。→ check-then-await 的 `loop { continue }` 会 re-check 条件、`drop(notified)` 释放未消费的 permit，伪唤醒只会多走一圈循环。
+- **[行为可观测性变化]** 恢复延迟从 O(100–500ms) 降为即时，是有意的改进；in-flight 上界与按序输出不变。回归测试需覆盖「慢 output + 快 input」下 in-flight 被压住、恢复后无丢消息。
+
+## Migration Plan
+
+纯内部实现重构：无配置项、无协议、无公共 API 变化；`tokio` 已是工作区依赖。部署即随新版本二进制生效；回滚 = `git revert` 单个 commit。无需灰度，无数据兼容性问题。
+
+## Open Questions
+
+- 未来是否进一步把 backpressure 改为「纯 `output_sender` 通道容量驱动」、移除 pending-count？那会让 in-flight 上界与 `tree_map` 乱序容量的耦合更松，但需重新论证 `tree_map` 有界性，留作独立 change。

--- a/openspec/changes/redesign-backpressure-notify/proposal.md
+++ b/openspec/changes/redesign-backpressure-notify/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Stream 的 backpressure 感知目前由 atomic + sleep 轮询实现：`do_processor` 在每次循环里 `load` 两个 `AtomicU64`（`sequence_counter` 与 `next_seq`），当 `pending > BACKPRESSURE_THRESHOLD (1024)` 时 `tokio::time::sleep(100–500ms)` 再 `continue`（`crates/arkflow-core/src/stream/mod.rs:342-353`）。`next_seq` 由 `do_output` 在按序写出后 `fetch_add(1, Release)` 推进（`crates/arkflow-core/src/stream/mod.rs:433`）。换言之，processor 在「等待 output 把 in-flight 管道排空」时，靠**周期性睡眠**去感知 output 的推进。
+
+这带来三个问题：
+
+1. **恢复延迟与吞吐抖动**：output 推进 `next_seq` 后，被阻塞的 processor 最多还要再睡一个完整的 `wait_time`（100–500ms，且 pending 越大睡得越久）才会重新检查。backpressure 期间的有效吞吐被人为压低，解除时呈阶梯式恢复而非即时恢复——这与「尽快排空积压」的目标相反。
+2. **轮询开销随并发放大**：每个 processor worker（`thread_num` 个）都独立 sleep-loop；未来提高 `thread_num` 会线性放大这种无效唤醒。
+3. **活跃性靠隐式假设、无契约/无测试**：当前的「最终能退出 backpressure」依赖「时间总会流逝、loop 总会回到 `recv`」这一副作用，仓库里没有任何针对 backpressure 的回归测试（`grep backpressure crates/arkflow-core/src/stream/mod.rs` 仅命中常量定义 `:35` 与使用点 `:346`），换信号机制时极易引入关闭/取消路径的死锁而无测试兜底。
+
+**Why now**：reliability roadmap（CDC / Schema Registry / 端到端 EOS / WAL 优化）刚落地，backpressure 是 at-least-once 与 EOS 下保证 in-flight 有界、`tree_map` 不无限增长的关键约束。在 EOS 之后处理它，恰好把「in-flight 有界 + 恢复即时 + 关闭无死锁」这一组一直隐式存在的质量属性形式化下来。
+
+## What Changes
+
+- 新增 `Arc<tokio::sync::Notify>` 信号，共享给所有 processor worker 与 output worker。
+- `do_output` 每次推进 `next_seq`（`fetch_add`）后调用 `notify_one()`，显式通知「in-flight 已排空一格」（每释放一格、精确唤醒一个 processor，且存 permit 不丢信号）。
+- `do_processor` 的 backpressure 由 `sleep` 轮询改为**检查后等待**：先获取 `notified()` future 注册 interest、再 `load` pending，超阈值则 `await` 该 future（规避 `Notify` 的丢信号语义）。
+- 移除 `wait_time` 计算与 `tokio::time::sleep` 调用（`crates/arkflow-core/src/stream/mod.rs:347-351`）。
+- 新增 backpressure 回归测试（当前为 0 条）。
+
+非 backpressure 的语义保持不变：阈值仍为 `BACKPRESSURE_THRESHOLD = 1024`、in-flight 上界不变、`do_output` 的顺序重排逻辑不变、s3 WAL flusher 不受影响（其本身已是 `Notify` 驱动，见 `crates/arkflow-plugin/src/wal/s3.rs:1080-1103`）。
+
+## Capabilities
+
+### New Capabilities
+
+- `stream-backpressure`: Stream 通过 sequence-number 驱动的 in-flight 上界对 processor 施加 backpressure 的可观测契约——in-flight 有界、解除即时（信号驱动而非轮询）、在输入结束与取消时保持无死锁的活跃性。
+
+### Modified Capabilities
+
+<!-- 无。现有 specs（message-acknowledgment、input-durability）对 backpressure 仅作泛指引用，其 requirement 不随本次实现机制变更而改变。 -->
+
+## Impact
+
+- **代码**：`crates/arkflow-core/src/stream/mod.rs`——`Stream` 结构体（新增 `Notify` 字段）、`Stream::new`、`run_inner`（创建并下发信号）、`do_processor`（轮询 → 信号）、`do_output`（推进 `next_seq` 后 `notify_one`）。
+- **API / 配置 / 依赖**：无变化。`tokio` 已是工作区依赖；不新增任何配置项；`BACKPRESSURE_THRESHOLD` 不变。
+- **可观测行为**：backpressure 恢复延迟由 O(100–500ms 轮询粒度) 降为即时；in-flight 上界与按序输出语义不变。
+- **测试**：`crates/arkflow-core/src/stream/mod.rs` 的 `tests` 模块新增 backpressure 回归用例。
+
+## Non-goals
+
+- 不改 backpressure 的**语义**（仍是限制「已分配 seq 未 output」的 in-flight ≤ ~1024，保证 `do_output` 的 `tree_map` 有界）。
+- 不改 `do_output` 的顺序重排（`BTreeMap` + `next_seq`）逻辑。
+- 不改 s3 WAL 的 background flusher（已是 `Notify` 驱动）。
+- 不调整 `BACKPRESSURE_THRESHOLD` 的值，也不把它做成可配置项。
+- 不重写 input 侧的重连退避（`do_input` 的 `sleep(5s)` 重连，`crates/arkflow-core/src/stream/mod.rs:271`）——那是断连重试退避，不属于 drain。

--- a/openspec/changes/redesign-backpressure-notify/specs/stream-backpressure/spec.md
+++ b/openspec/changes/redesign-backpressure-notify/specs/stream-backpressure/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: In-flight messages stay bounded
+Stream SHALL limit, before each processor worker reads its next input, the number of in-flight messages — those with an assigned sequence number not yet written out in order by the output — so that it does not exceed an upper bound of `BACKPRESSURE_THRESHOLD` plus the processor concurrency, ensuring `do_output`'s reorder buffer (`BTreeMap`) does not grow without bound.
+
+#### Scenario: In-flight held near the threshold under a slow output
+- **WHEN** the output writes persistently slower than the input and processors produce, so in-flight keeps accumulating
+- **THEN** the processor worker stops reading new input once in-flight reaches the upper bound, and does not resume until the output writes one message in order and advances `next_seq` to release a slot
+
+#### Scenario: No backpressure under a fast output
+- **WHEN** the output writes fast and in-flight stays below `BACKPRESSURE_THRESHOLD`
+- **THEN** the processor worker enters no wait and continuously reads and processes input
+
+### Requirement: Backpressure release is signal-driven
+When in-flight drops below the threshold because the output advanced `next_seq`, Stream SHALL immediately wake the blocked processor worker via an explicit signal (`tokio::sync::Notify`), rather than relying on periodic polling or a fixed sleep.
+
+#### Scenario: Processor resumes immediately after the output advances
+- **WHEN** a processor worker is waiting under backpressure and the output writes one message in order, bringing in-flight back below the threshold
+- **THEN** the processor worker is woken immediately by the signal emitted when the output advances `next_seq`, without waiting for a fixed sleep interval
+
+### Requirement: Liveness under input end and cancellation
+Stream SHALL guarantee that all processor and output workers eventually exit on input end (EOF) or cancellation, without deadlocking on a backpressure wait.
+
+#### Scenario: Drains and exits despite backpressure at input EOF
+- **WHEN** the input emits EOF while more than the threshold in-flight messages remain unwritten and a processor worker is waiting under backpressure
+- **THEN** the output worker keeps draining the remaining in-flight in order, advancing `next_seq` and emitting a signal per message written so that the processor worker is woken incrementally; once in-flight drops below the threshold, the processor worker observes the input channel closing and exits, after which the output worker flushes any residue left in the reorder buffer and exits
+
+### Requirement: Ordered-output semantics unaffected by the backpressure mechanism
+Changing the backpressure signaling mechanism SHALL NOT alter the semantics that the output writes messages in ascending sequence-number order.
+
+#### Scenario: Still written in order across repeated backpressure cycles
+- **WHEN** multiple processor workers process concurrently and backpressure is entered and exited repeatedly during the run
+- **THEN** the output worker still writes messages strictly in ascending `next_seq` order, with no reordering or loss

--- a/openspec/changes/redesign-backpressure-notify/tasks.md
+++ b/openspec/changes/redesign-backpressure-notify/tasks.md
@@ -1,0 +1,40 @@
+## 1. 在 Stream 引入 backpressure 信号
+
+- [x] 1.1 在 `Stream` 结构体新增字段 `next_seq_notify: Arc<tokio::sync::Notify>`，与 `sequence_counter` / `next_seq` 并列。
+- [x] 1.2 在 `Stream::new` 初始化 `next_seq_notify: Arc::new(Notify::new())`；在 `use` 区补 `use tokio::sync::Notify;`（Decision 4）。
+- [x] 1.3 Verify：`cargo build -p arkflow-core` 成功（2.32s）。`tokio` 的 `full` feature 已含 `sync`，无需改 `Cargo.toml`。
+
+## 2. `do_output` 推进 `next_seq` 后发信号
+
+- [x] 2.1 给 `do_output` 增加 `next_seq_notify: Arc<Notify>` 参数；在 `next_seq.fetch_add(1, Release)` 之后紧跟 `next_seq_notify.notify_one();`（Decision 2）。
+- [x] 2.2 在 `run_inner` 调用 `do_output` 处传入 `self.next_seq_notify.clone()`。
+- [x] 2.3 Verify：`cargo build -p arkflow-core` 成功；clippy 对本改动的 stream/mod.rs 部分无新增 warning（见 5.2 的 pre-existing 注记）。
+
+## 3. `do_processor` 的 backpressure 改为 check-then-await
+
+- [x] 3.1 给 `do_processor` 增加 `next_seq_notify: Arc<Notify>` 参数；在 `run_inner` 调用处传入 `self.next_seq_notify.clone()`。
+- [x] 3.2 将 backpressure 块按 Decision 3 重写：先 `let notified = next_seq_notify.notified();`，再 `load` 两量算 `pending`；若 `pending > BACKPRESSURE_THRESHOLD` 则 `notified.await;` 后 `continue;`，否则 `drop(notified);` 落到既有 `recv_async`。**移除** `wait_time` 计算与 `tokio::time::sleep(...)` 调用。
+- [x] 3.3 核对 `use` 区无 orphan import；`do_input` 的重连退避 `sleep` 未动。
+- [x] 3.4 Verify：`cargo build -p arkflow-core` 成功；`drop(notified)` 未触发任何 clippy lint（`Notified` 实现 `Drop`，不报 `drop_non_drop`）。
+
+## 4. Backpressure 回归测试
+
+> 实现说明：原计划的「门控 mock output + 端到端驱动」改为对 `do_processor` / `do_output` 的**直接单元测试**。原因——端到端触发 backpressure 需 `strand 异速`（一个 processor 卡住 `next_seq`、其余狂奔领号），构造困难且 flaky；直接单测能精确、稳定地覆盖 spec 三条 requirement + 活跃性。两个测试加入 `stream::tests`：`processor_worker_waits_on_notify_under_backpressure`、`output_worker_notifies_on_next_seq_advance`。
+
+- [x] 4.1 `processor_worker_waits_on_notify_under_backpressure`：构造 `sequence_counter=2×THRESHOLD`、`next_seq=0`（in-flight 超阈值），断言 processor 不消费输入（`output_rx.is_empty()`）；推进 `next_seq` + `notify_one()` 后断言即时恢复并产出；`drop(input_tx)` 后断言 worker 在 timeout 内观察 EOF 退出（无死锁）——覆盖 spec「In-flight 上界保持有界」「Backpressure 解除为信号驱动」「活跃性」。
+- [x] 4.2 `output_worker_notifies_on_next_seq_advance`：投递 `seq=0 == next_seq` 的 batch，断言 `notify` 被触发且 `next_seq` 推进到 1——覆盖信号源端语义。按序输出由既有 `output_worker_calls_write_batch_once_per_ack_range` 等测试持续守护。
+- [x] 4.3 时序断言用 `is_empty()` / `timeout` / 计数器，仅在「等待 worker 进入 backpressure」处用一次 100ms sleep（测试设施，非被测机制）。
+- [x] 4.4 活跃性由 4.1 的 EOF 退出分支覆盖。
+- [x] 4.5 Verify：`cargo test -p arkflow-core` 全过（146 passed; 0 failed），含两个新测试。
+
+## 5. 全量验证
+
+- [x] 5.1 `cargo test --workspace --lib` 全绿：arkflow-plugin 221 + arkflow-core 146 passed; 0 failed。需外部服务（kafka/postgres/…）的 plugin 集成测试按惯例在 CI 跑，本地跳过；本改动仅触及 `stream/mod.rs` 内部，不影响 plugin 对 `Input/Output/Processor` trait 的实现。
+- [x] 5.2 `cargo clippy -p arkflow-core`：本改动（`Notify` / check-then-await / `drop(notified)` / 两个测试）**零新增 warning**。stream/mod.rs 上的 2 个 warning 为 **pre-existing**（`Stream::new` too_many_arguments、`do_output` 内层 loop 的 while_let_loop），经 `git stash` 对比确认改动前后数量不变，不在本次范围。
+- [x] 5.3 `cargo fmt -p arkflow-core -- --check`：本改动干净。stream/mod.rs 与 codec/mod.rs 的 2 处 diff 为 **pre-existing**（`git stash` 对比确认），不在本次范围。
+- [x] 5.4 手动核对：`do_processor` 已无用于 backpressure 的 `tokio::time::sleep`（仅 `do_input` 重连退避 `:279` 与测试内的等待保留）；`do_output` 每次 `next_seq.fetch_add`（`:444`）后均调用 `notify_one()`（`:445`）。
+
+## 6. OpenSpec 校验与归档
+
+- [x] 6.1 `openspec status`：4/4 artifact done；`openspec validate redesign-backpressure-notify --strict` 通过。
+- [ ] 6.2 待用户决定：合入后走 `/opsx:archive` 归档，将 `specs/stream-backpressure/spec.md` 同步进 `openspec/specs/stream-backpressure/`。


### PR DESCRIPTION
## Summary
Replace the stream's only atomic-poll drain -- `do_processor`'s backpressure `sleep`-loop (100-500ms between `AtomicU64` loads) -- with an explicit `tokio::sync::Notify` signal driven by `do_output`'s `next_seq` advances.

- `do_output` calls `notify_one()` after each `next_seq.fetch_add`
- `do_processor` uses check-then-await (`notified()` before `load`) -> immediate wake on release, no sleep tick
- `notify_one` stores a permit -> no lost signal; one wake per freed slot -> no thundering herd

## Liveness
`pending > THRESHOLD` implies the output still has in-flight to write, so it advances `next_seq` + notifies again -- a blocked processor is always woken. EOF/cancel drains faster than the old sleep-tick behavior.

## Preserved
`BACKPRESSURE_THRESHOLD = 1024`, the in-flight bound, and `do_output`'s ordered-reorder logic are unchanged.

## Tests
- `cargo test -p arkflow-core` -- 146 passed (incl. 2 new: `processor_worker_waits_on_notify_under_backpressure`, `output_worker_notifies_on_next_seq_advance`)
- `cargo test --workspace --lib` -- plugin 221 + core 146, 0 failed
- clippy/fmt: this change is clean (2 pre-existing warnings/diffs in stream/mod.rs confirmed via `git stash`, out of scope)

## Spec
Adds OpenSpec change `redesign-backpressure-notify` with a new `stream-backpressure` capability (in-flight bound, signal-driven release, EOF/cancel liveness, ordered output).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved stream backpressure handling with event-driven coordination instead of periodic polling.
  * Reduced unnecessary waiting while preserving bounded in-flight messages and ordered output.
  * Improved worker responsiveness when processing resumes.

* **Reliability**
  * Added coverage for backpressure blocking, resumption, output progress, cancellation, and clean shutdown.
  * Preserved stream behavior during repeated backpressure cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->