### PR TITLE
feat(core): surface line/column locations in config parse errors

### DIFF
--- a/crates/arkflow-core/src/configuration.rs
+++ b/crates/arkflow-core/src/configuration.rs
@@ -127,18 +127,48 @@ pub enum ConfigFormat {
 impl ConfigCandidate {
     pub fn parse(&self) -> Result<EngineConfig, ConfigIssue> {
         match self.format {
-            ConfigFormat::Yaml => serde_yaml::from_str(&self.content).map_err(parse_error),
-            ConfigFormat::Json => serde_json::from_str(&self.content).map_err(parse_error),
-            ConfigFormat::Toml => toml::from_str(&self.content).map_err(parse_error),
+            ConfigFormat::Yaml => serde_yaml::from_str(&self.content).map_err(|error| {
+                let path = error
+                    .location()
+                    .map(|location| {
+                        format!("line {}, column {}", location.line(), location.column())
+                    })
+                    .unwrap_or_else(|| "document".to_string());
+                parse_error_at(path, error)
+            }),
+            ConfigFormat::Json => serde_json::from_str(&self.content).map_err(|error| {
+                parse_error_at(
+                    format!("line {}, column {}", error.line(), error.column()),
+                    error,
+                )
+            }),
+            ConfigFormat::Toml => toml::from_str(&self.content).map_err(|error| {
+                let path = error
+                    .span()
+                    .map(|span| location_for_offset(&self.content, span.start))
+                    .unwrap_or_else(|| "document".to_string());
+                parse_error_at(path, error)
+            }),
         }
     }
 }
 
-fn parse_error(error: impl std::fmt::Display) -> ConfigIssue {
+fn parse_error_at(path: String, error: impl std::fmt::Display) -> ConfigIssue {
     ConfigIssue {
-        path: "".to_string(),
+        path,
         message: error.to_string(),
     }
+}
+
+fn location_for_offset(content: &str, offset: usize) -> String {
+    let prefix = &content[..offset.min(content.len())];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix
+        .rsplit('\n')
+        .next()
+        .map_or(0, |line| line.chars().count())
+        + 1;
+    format!("line {line}, column {column}")
 }
 
 /// Validate syntax, Stream identities, and component construction without
@@ -237,7 +267,11 @@ mod tests {
             format: ConfigFormat::Json,
             content: "not-json".to_string(),
         };
-        assert_eq!(invalid.parse().unwrap_err().path, "");
+        assert!(invalid
+            .parse()
+            .unwrap_err()
+            .path
+            .starts_with("line 1, column"));
     }
 
     #[test]

--- a/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/design.md
+++ b/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The console is a small React/Vite application with a single configuration workflow. The API accepts YAML, JSON, and TOML candidates and returns asynchronous operations for apply/rollback. The active configuration endpoint is intentionally redacted, so it cannot safely be treated as an editable source of truth. Existing local draft state, validation state, and operation state are currently coupled too loosely.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve an exact `(format, content)` pair for every editor state and validation result.
+- Convert structured configuration between supported formats when the operator changes the selector, rejecting conversion when content is not parseable.
+- Keep redacted active content read-only until a real draft exists.
+- Wait for apply/rollback operations to reach a terminal state before refreshing data.
+- Give syntax failures a line/column path and retain semantic field paths.
+
+**Non-Goals:**
+
+- Replacing the textarea with a full IDE/editor.
+- Recovering secret values from redacted active configuration.
+- Changing the control-plane operation state machine.
+
+## Decisions
+
+1. **Represent validation identity by both format and content.** The UI will store a serialized candidate identity (format plus content), clear validation on either change, and enable publish only when the exact current candidate has a successful report. This avoids stale validation after format-only edits.
+
+2. **Use a small frontend YAML/JSON conversion path.** The page currently exposes YAML and JSON selectors, so it will parse either into a format-neutral value with the `yaml` package and stringify into the target format. TOML remains an API-supported candidate format but is not presented as a browser-convertible option. The original content is kept if conversion fails while showing an error.
+
+3. **Model redacted active configuration as read-only.** When no draft exists, the active response is rendered as a display snapshot and publish/save controls remain unavailable until the operator edits or creates a draft. A redaction marker is never sent back as a secret replacement implicitly.
+
+4. **Reuse operation polling semantics.** Configuration apply and rollback will use the same terminal-state polling helper as lifecycle commands. Only succeeded/converged operations trigger `load`; failure leaves the editor and failure details intact.
+
+5. **Enrich parser issue locations without changing endpoint shape.** `ConfigIssue.path` remains a string; parser errors are normalized to `line N, column M` when available, while semantic validation continues to use paths such as `streams[0]`.
+
+## Risks / Trade-offs
+
+- [Risk] YAML/TOML serialization can change comments or stylistic formatting. → Treat conversion as a semantic conversion and clearly invalidate validation; preserve text until the operator explicitly changes format.
+- [Risk] A redacted active snapshot may not be publishable as-is. → Keep it display-only and require a separately saved draft for mutation.
+- [Risk] Polling can outlive the page interaction. → Bound polling and report timeout without refreshing active configuration.

--- a/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/proposal.md
+++ b/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The control-plane configuration page currently treats a format selector as metadata while leaving the editor content unchanged (`console/src/features.tsx:115-116`), and it reloads immediately after receiving an asynchronous publish operation instead of waiting for its terminal result (`console/src/features.tsx:106-108`). As a result, operators can validate one representation, publish another, lose operation failures, or accidentally work from a redacted runtime snapshot. Configuration parsing errors also lose their location because the server maps parser failures to an empty path (`crates/arkflow-core/src/configuration.rs:127-132`).
+
+## What Changes
+
+- Make the editor's format and content a single consistent candidate; convert content when changing between supported formats and invalidate validation whenever either changes.
+- Keep redacted active configuration display-only, while allowing a separately loaded/saved draft to be edited and published.
+- Render syntax and semantic validation failures with usable path/line context and prevent publishing anything other than the exact successfully validated candidate.
+- Track publish and rollback operations through terminal state, refresh active configuration only after success, and preserve actionable failure feedback.
+- Add focused console and core/server regression coverage for format changes, stale validation, redacted configuration, and asynchronous mutation outcomes.
+
+## Capabilities
+
+### New Capabilities
+
+- `console-configuration-workflow`: Consistent multi-format editing, validation, draft/publish, and operation feedback in the control-plane console.
+
+### Modified Capabilities
+
+<!-- No checked-in main capability spec currently covers the console configuration page. -->
+
+## Impact
+
+- Frontend: `console/src/features.tsx`, `console/src/api.ts`, and console tests.
+- Core/server: configuration parsing error metadata and validation endpoint behavior/tests where needed.
+- Adds the small frontend `yaml` parser/serializer dependency; no runtime endpoint removals, and request/response shapes remain backward-compatible except for richer validation issue paths.
+
+## Non-goals
+
+- Redesigning the overall control-plane navigation or runtime pages.
+- Exposing unredacted active configuration secrets.
+- Adding a new configuration language beyond the formats already accepted by the API.

--- a/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/specs/console-configuration-workflow/spec.md
+++ b/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/specs/console-configuration-workflow/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Consistent configuration candidates
+
+The console SHALL treat configuration format and content as one candidate. Changing either SHALL invalidate the previous validation result, and changing format SHALL convert parseable content before making it the new candidate.
+
+#### Scenario: Convert a valid candidate
+- **WHEN** an operator changes a valid YAML candidate to JSON
+- **THEN** the editor contains equivalent JSON content, the selected format is JSON, and the candidate requires validation again
+
+#### Scenario: Reject an unconvertible candidate
+- **WHEN** an operator changes a malformed candidate's format
+- **THEN** the original content is preserved, validation is cleared, and a visible conversion error is shown
+
+### Requirement: Safe draft and redacted active configuration
+
+The console MUST distinguish an editable draft from the redacted active configuration. Redacted active values SHALL remain display-only and SHALL never be implicitly published as replacement secrets.
+
+#### Scenario: No draft exists
+- **WHEN** the configuration page loads only a redacted active configuration
+- **THEN** the page displays it as read-only and does not enable Save draft or Publish
+
+#### Scenario: Draft exists
+- **WHEN** an editable draft is loaded
+- **THEN** the editor uses the draft format/content and permits saving and validating that draft
+
+### Requirement: Exact validation gate
+
+Publish SHALL be enabled only when the exact current format/content candidate has a successful validation report and is not dirty relative to the saved draft. Validation issues SHALL include a document path or a line/column location for syntax errors and structured field paths for semantic errors.
+
+#### Scenario: Edit after validation
+- **WHEN** an operator changes content or format after a successful validation
+- **THEN** Publish becomes disabled until the new exact candidate is successfully validated
+
+#### Scenario: Invalid candidate
+- **WHEN** validation returns syntax or semantic errors
+- **THEN** the UI renders each issue with its path/location and does not call the publish endpoint
+
+### Requirement: Terminal configuration mutations
+
+Apply and rollback SHALL track the returned operation through a terminal success or failure state. The console SHALL refresh active configuration and version history only after success, and SHALL preserve actionable failure information otherwise.
+
+#### Scenario: Successful publish
+- **WHEN** a validated draft is published and its operation converges successfully
+- **THEN** the console refreshes configuration/version data and reports the successful terminal result
+
+#### Scenario: Failed publish
+- **WHEN** a publish operation fails, times out, or is blocked
+- **THEN** the console reports the failure and does not replace the current editor content or reload active configuration

--- a/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/tasks.md
+++ b/openspec/changes/archive/2026-08-02-harden-console-configuration-workflow/tasks.md
@@ -1,0 +1,16 @@
+## 1. Core and API validation contracts
+
+- [x] 1.1 Normalize configuration parser errors into useful line/column paths while preserving semantic paths, with Rust unit coverage.
+- [x] 1.2 Add/adjust API types and helpers needed to represent exact candidate identity and terminal configuration operation outcomes.
+
+## 2. Console configuration workflow
+
+- [x] 2.1 Add the YAML parser/serializer dependency and format conversion helpers for the UI's YAML/JSON formats; make format/content changes invalidate validation atomically.
+- [x] 2.2 Separate redacted active configuration display from editable draft state and gate Save draft/Publish accordingly.
+- [x] 2.3 Poll apply and rollback operations to terminal state, refresh only after success, and retain failure/timeout feedback.
+- [x] 2.4 Render path-aware validation/conversion issues and enforce the exact validated candidate publish gate.
+
+## 3. Regression coverage and verification
+
+- [x] 3.1 Add console tests for format conversion, stale validation, redacted display-only behavior, and async publish success/failure.
+- [x] 3.2 Run console typecheck/tests/build and focused Rust tests; validate the OpenSpec change.


### PR DESCRIPTION
## Summary

- Normalize YAML/JSON/TOML configuration parser failures into a `line N, column M` path in `ConfigIssue`, replacing the previous empty path so operators can jump directly to the syntax error.
- Introduce `parse_error_at(path, error)` and a `location_for_offset` helper (used for TOML's byte-span errors), and update the unit test to assert the new location prefix.
- Archive the `harden-console-configuration-workflow` OpenSpec change documenting this work.

## Why

The control-plane configuration page could not point operators at the exact position of a syntax error because the server mapped parser failures to an empty path (`crates/arkflow-core/src/configuration.rs`). This is the Rust-side piece (task 1.1) of the `harden-console-configuration-workflow` change; request/response shapes remain backward-compatible.

## Test plan

- [x] `cargo test -p arkflow-core` (config parse error unit test updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration parsing errors now include precise source locations, including paths, lines, and columns where available.
  * Improved error formatting makes invalid YAML, JSON, and TOML configuration easier to identify and correct.

* **Documentation**
  * Added detailed guidance for configuration editing, format conversion, validation, publishing, rollback behavior, and operation status tracking.
  * Documented safeguards for drafts, redacted active configurations, and stale validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->