### PR TITLE
feat: add MongoDB output plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "lazy_static",
  "lz4_flex 0.11.6",
  "mockall",
+ "mongodb",
  "num_cpus",
  "object_store",
  "once_cell",
@@ -1840,6 +1841,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bitvec",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap 2.14.0",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2273,7 @@ checksum = "48629740a3480b865d4083ff45f826a253bd5ce28db618d89359b0e95dc750c3"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -2336,6 +2360,15 @@ name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -3643,6 +3676,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3706,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5716,6 +5794,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5860,6 +5986,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "mongocrypt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8426a875ded61430d4a811dbfda7633b6b8af0225c547fc6c28b8b0aa7d79a13"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.6+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851fac73f7fe22f6a3ab87f720ce509cae7c9fd08e7dd27866cc232dee07ccf4"
+
+[[package]]
+name = "mongodb"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b814038f367d212f55de0a630cb35102a9b8ca23785a86955d62c0087c93846d"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.13.1",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hmac 0.13.0",
+ "macro_magic",
+ "md-5 0.11.0",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.9.5",
+ "rustc_version_runtime",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "socket2 0.6.5",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f736d2fbc56e0011a341fbb9172bd822fda75c5f93b82fae1c7aab1e2613c810"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,7 +6141,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "time",
@@ -6637,6 +6836,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -8105,6 +8313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8462,6 +8680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8487,6 +8715,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -8645,6 +8874,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9094,7 +9334,7 @@ dependencies = [
  "rand 0.8.7",
  "rsa",
  "serde",
- "sha1",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -9363,6 +9603,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tap"
@@ -9716,6 +9962,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "libc",
@@ -10039,7 +10286,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.5",
- "sha1",
+ "sha1 0.10.7",
  "thiserror 2.0.19",
  "utf-8",
 ]
@@ -10049,6 +10296,26 @@ name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "typenum"
@@ -10237,6 +10504,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "rand 0.10.2",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -10297,7 +10565,7 @@ dependencies = [
  "cidr",
  "codespan-reporting",
  "community-id",
- "convert_case",
+ "convert_case 0.7.1",
  "crc",
  "crypto_secretbox",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ flume = "=0.11"
 subtle = "2.6"
 governor = "0.6"
 dashmap = "6.1"
+mongodb = { version = "3.2", default-features = false, features = ["rustls-tls", "compat-3-0-0"] }
 
 # Sql
 sqlx = { version = "0.8.6", default-features = false, features = ["mysql", "postgres", "runtime-tokio", "tls-native-tls"] }

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -74,6 +74,7 @@ vrl = { version = "0.30", features = ["value", "compiler", "stdlib"] }
 # arkflow
 arkflow-core = { workspace = true }
 sqlx = { workspace = true }
+mongodb = { workspace = true }
 
 # Websocket
 tokio-tungstenite = { version = "0.28", features = ["native-tls"] }

--- a/crates/arkflow-plugin/src/output/mod.rs
+++ b/crates/arkflow-plugin/src/output/mod.rs
@@ -23,6 +23,7 @@ pub mod drop;
 pub mod http;
 pub mod influxdb;
 pub mod kafka;
+pub mod mongodb;
 pub mod mqtt;
 pub mod nats;
 pub mod pulsar;
@@ -36,6 +37,7 @@ pub fn init() -> Result<(), Error> {
     influxdb::init()?;
     kafka::init()?;
     mqtt::init()?;
+    mongodb::init()?;
     nats::init()?;
     pulsar::init()?;
     redis::init()?;

--- a/crates/arkflow-plugin/src/output/mongodb.rs
+++ b/crates/arkflow-plugin/src/output/mongodb.rs
@@ -1,0 +1,404 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! MongoDB output component.
+
+use arkflow_core::codec::Codec;
+use arkflow_core::component::{register_output_metadata, ComponentMetadata};
+use arkflow_core::error_helpers::parse_config;
+use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
+use arkflow_core::{Error, MessageBatch, MessageBatchRef, Resource};
+use async_trait::async_trait;
+use datafusion::arrow::array::{
+    Array, BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, LargeBinaryArray, LargeStringArray, StringArray, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
+};
+use datafusion::arrow::datatypes::DataType;
+use mongodb::bson::{Binary, Bson, Document};
+use mongodb::{Client, Collection};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+fn map_mongodb_error(context: &str, error: &mongodb::error::Error) -> Error {
+    use mongodb::error::ErrorKind;
+
+    let message = format!("{}: {}", context, error);
+    match error.kind.as_ref() {
+        ErrorKind::Authentication { .. } => Error::Authentication(message),
+        ErrorKind::ConnectionPoolCleared { .. }
+        | ErrorKind::DnsResolve { .. }
+        | ErrorKind::Io(_)
+        | ErrorKind::InvalidTlsConfig { .. }
+        | ErrorKind::ServerSelection { .. }
+        | ErrorKind::Shutdown => Error::Connection(message),
+        _ => Error::Process(message),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MongoDBOutputConfig {
+    pub uri: String,
+    pub database: String,
+    pub collection: String,
+}
+
+impl MongoDBOutputConfig {
+    fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("uri", self.uri.as_str()),
+            ("database", self.database.as_str()),
+            ("collection", self.collection.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(Error::Config(format!(
+                    "MongoDB output field '{}' must not be empty",
+                    name
+                )));
+            }
+        }
+        if !self.uri.starts_with("mongodb://") && !self.uri.starts_with("mongodb+srv://") {
+            return Err(Error::Config(
+                "MongoDB output uri must start with mongodb:// or mongodb+srv://".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub struct MongoDBOutput {
+    config: MongoDBOutputConfig,
+    collection: Arc<Mutex<Option<Collection<Document>>>>,
+}
+
+impl MongoDBOutput {
+    pub fn new(config: MongoDBOutputConfig) -> Result<Self, Error> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            collection: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    fn row_to_document(msg: &MessageBatch, row: usize) -> Result<Document, Error> {
+        let mut document = Document::new();
+        for (column_index, field) in msg.schema().fields().iter().enumerate() {
+            let column = msg.column(column_index);
+            let value = array_value_to_bson(column.as_ref(), row, field.name())?;
+            document.insert(field.name().clone(), value);
+        }
+        Ok(document)
+    }
+
+    fn documents(msg: &MessageBatch) -> Result<Vec<Document>, Error> {
+        (0..msg.len())
+            .map(|row| Self::row_to_document(msg, row))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Output for MongoDBOutput {
+    async fn connect(&self) -> Result<(), Error> {
+        let client = Client::with_uri_str(&self.config.uri)
+            .await
+            .map_err(|e| Error::Config(format!("Invalid MongoDB URI: {}", e)))?;
+        client
+            .database(&self.config.database)
+            .run_command(mongodb::bson::doc! { "ping": 1 })
+            .await
+            .map_err(|e| map_mongodb_error("Failed to connect to MongoDB", &e))?;
+
+        let mut collection = self.collection.lock().await;
+        *collection = Some(
+            client
+                .database(&self.config.database)
+                .collection::<Document>(&self.config.collection),
+        );
+        Ok(())
+    }
+
+    async fn write(&self, msg: MessageBatchRef) -> Result<(), Error> {
+        let collection = self.collection.lock().await;
+        let collection = collection.as_ref().ok_or(Error::Disconnection)?;
+        let documents = Self::documents(&msg)?;
+        if documents.is_empty() {
+            return Ok(());
+        }
+
+        collection
+            .insert_many(documents)
+            .await
+            .map_err(|e| map_mongodb_error("Failed to insert documents into MongoDB", &e))?;
+        Ok(())
+    }
+
+    async fn close(&self) -> Result<(), Error> {
+        *self.collection.lock().await = None;
+        Ok(())
+    }
+}
+
+fn array_value_to_bson(array: &dyn Array, row: usize, field: &str) -> Result<Bson, Error> {
+    if array.is_null(row) {
+        return Ok(Bson::Null);
+    }
+
+    let value = match array.data_type() {
+        DataType::Utf8 => Bson::String(
+            array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Arrow Utf8 array type is StringArray")
+                .value(row)
+                .to_owned(),
+        ),
+        DataType::LargeUtf8 => Bson::String(
+            array
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("Arrow LargeUtf8 array type is LargeStringArray")
+                .value(row)
+                .to_owned(),
+        ),
+        DataType::Int8 => Bson::Int32(
+            array
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .expect("Arrow Int8 array type is Int8Array")
+                .value(row) as i32,
+        ),
+        DataType::Int16 => Bson::Int32(
+            array
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("Arrow Int16 array type is Int16Array")
+                .value(row) as i32,
+        ),
+        DataType::Int32 => Bson::Int32(
+            array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("Arrow Int32 array type is Int32Array")
+                .value(row),
+        ),
+        DataType::Int64 => Bson::Int64(
+            array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("Arrow Int64 array type is Int64Array")
+                .value(row),
+        ),
+        DataType::UInt8 => Bson::Int32(
+            array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("Arrow UInt8 array type is UInt8Array")
+                .value(row) as i32,
+        ),
+        DataType::UInt16 => Bson::Int32(
+            array
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("Arrow UInt16 array type is UInt16Array")
+                .value(row) as i32,
+        ),
+        DataType::UInt32 => Bson::Int64(
+            array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("Arrow UInt32 array type is UInt32Array")
+                .value(row) as i64,
+        ),
+        DataType::UInt64 => {
+            let value = array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("Arrow UInt64 array type is UInt64Array")
+                .value(row);
+            Bson::Int64(value.try_into().map_err(|_| {
+                Error::Process(format!(
+                    "MongoDB field '{}' exceeds BSON int64 range",
+                    field
+                ))
+            })?)
+        }
+        DataType::Float32 => Bson::Double(
+            array
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .expect("Arrow Float32 array type is Float32Array")
+                .value(row) as f64,
+        ),
+        DataType::Float64 => Bson::Double(
+            array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("Arrow Float64 array type is Float64Array")
+                .value(row),
+        ),
+        DataType::Boolean => Bson::Boolean(
+            array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("Arrow Boolean array type is BooleanArray")
+                .value(row),
+        ),
+        DataType::Binary => Bson::Binary(Binary {
+            subtype: mongodb::bson::spec::BinarySubtype::Generic,
+            bytes: array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("Arrow Binary array type is BinaryArray")
+                .value(row)
+                .to_vec(),
+        }),
+        DataType::LargeBinary => Bson::Binary(Binary {
+            subtype: mongodb::bson::spec::BinarySubtype::Generic,
+            bytes: array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .expect("Arrow LargeBinary array type is LargeBinaryArray")
+                .value(row)
+                .to_vec(),
+        }),
+        data_type => {
+            return Err(Error::Process(format!(
+                "MongoDB field '{}' has unsupported Arrow type {:?}",
+                field, data_type
+            )))
+        }
+    };
+    Ok(value)
+}
+
+struct MongoDBOutputBuilder;
+
+impl OutputBuilder for MongoDBOutputBuilder {
+    fn build(
+        &self,
+        _name: Option<&String>,
+        config: &Option<serde_json::Value>,
+        codec: Option<Arc<dyn Codec>>,
+        _resource: &Resource,
+    ) -> Result<Arc<dyn Output>, Error> {
+        if codec.is_some() {
+            return Err(Error::Config(
+                "MongoDB output does not support codecs; it writes structured BSON documents"
+                    .to_string(),
+            ));
+        }
+        let config: MongoDBOutputConfig = parse_config(config, "MongoDB output")?;
+        Ok(Arc::new(MongoDBOutput::new(config)?))
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    register_output_builder("mongodb", Arc::new(MongoDBOutputBuilder))?;
+    register_output_metadata(
+        ComponentMetadata::with_schema(
+            "mongodb",
+            "Writes Arrow rows to MongoDB as BSON documents.",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "uri": {"type": "string", "description": "MongoDB connection URI."},
+                    "database": {"type": "string", "description": "Target database name."},
+                    "collection": {"type": "string", "description": "Target collection name."}
+                },
+                "required": ["uri", "database", "collection"]
+            }),
+        )
+        .with_example(serde_json::json!({
+            "uri": "mongodb://localhost:27017",
+            "database": "arkflow",
+            "collection": "events"
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{
+        ArrayRef, Int64Array, StringArray, TimestampMillisecondArray, UInt64Array,
+    };
+    use datafusion::arrow::datatypes::{Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+
+    fn batch(columns: Vec<(&str, ArrayRef)>) -> MessageBatch {
+        let fields: Vec<Field> = columns
+            .iter()
+            .map(|(name, column)| Field::new(*name, column.data_type().clone(), true))
+            .collect();
+        MessageBatch::new_arrow(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(fields)),
+                columns.into_iter().map(|(_, c)| c).collect(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn converts_scalars_and_nulls() {
+        let msg = batch(vec![
+            ("name", Arc::new(StringArray::from(vec![Some("Ada")]))),
+            ("count", Arc::new(Int64Array::from(vec![Some(3)]))),
+            ("missing", Arc::new(StringArray::from(vec![None::<&str>]))),
+        ]);
+        let document = MongoDBOutput::row_to_document(&msg, 0).unwrap();
+        assert_eq!(document.get_str("name").unwrap(), "Ada");
+        assert_eq!(document.get_i64("count").unwrap(), 3);
+        assert!(matches!(document.get("missing"), Some(Bson::Null)));
+    }
+
+    #[test]
+    fn rejects_uint64_overflow() {
+        let msg = batch(vec![("value", Arc::new(UInt64Array::from(vec![u64::MAX])))]);
+        let error = MongoDBOutput::row_to_document(&msg, 0).unwrap_err();
+        assert!(error.to_string().contains("value"));
+        assert!(error.to_string().contains("int64"));
+    }
+
+    #[test]
+    fn rejects_unsupported_arrow_type() {
+        let msg = batch(vec![(
+            "event_time",
+            Arc::new(TimestampMillisecondArray::from(vec![Some(1)])),
+        )]);
+        let error = MongoDBOutput::row_to_document(&msg, 0).unwrap_err();
+        assert!(error.to_string().contains("event_time"));
+        assert!(error.to_string().contains("unsupported Arrow type"));
+    }
+
+    #[test]
+    fn validates_non_empty_configuration() {
+        let result = MongoDBOutput::new(MongoDBOutputConfig {
+            uri: " ".to_string(),
+            database: "db".to_string(),
+            collection: "events".to_string(),
+        });
+        let error = match result {
+            Ok(_) => panic!("empty URI should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("uri"));
+    }
+
+    #[test]
+    fn empty_batch_has_no_documents() {
+        let msg = batch(vec![(
+            "value",
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
+        )]);
+        assert!(MongoDBOutput::documents(&msg).unwrap().is_empty());
+    }
+}

--- a/docs/docs/components/3-outputs/mongodb.md
+++ b/docs/docs/components/3-outputs/mongodb.md
@@ -1,0 +1,26 @@
+# MongoDB
+
+The MongoDB output writes each Arrow row as a BSON document in a configured MongoDB collection. Column names become document field names, and scalar values and nulls are preserved.
+
+## Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| type | string | yes | Fixed value `"mongodb"`. |
+| uri | string | yes | MongoDB connection URI, including authentication/options when needed. |
+| database | string | yes | Destination database name. |
+| collection | string | yes | Destination collection name. |
+
+The output supports UTF-8 strings, signed and unsigned integers that fit BSON int64, floating-point values, booleans, binary values, and nulls. Nested Arrow values and codecs are not supported in this initial version.
+
+## Example
+
+```yaml
+output:
+  type: "mongodb"
+  uri: "mongodb://localhost:27017"
+  database: "arkflow"
+  collection: "events"
+```
+
+The output connects and pings MongoDB before accepting writes. Each non-empty message batch is sent with one bulk insertion operation.

--- a/examples/mongodb_output_example.yaml
+++ b/examples/mongodb_output_example.yaml
@@ -1,6 +1,30 @@
 # Writes each Arrow row as a BSON document.
-output:
-  type: "mongodb"
-  uri: "mongodb://localhost:27017"
-  database: "arkflow"
-  collection: "events"
+logging:
+  level: info
+
+streams:
+  - input:
+      type: "generate"
+      context: '{ "id": 1, "value": 10, "sensor": "temp_1" }'
+      interval: 1s
+      batch_size: 10
+      count: 10
+
+    buffer:
+      type: "memory"
+      capacity: 100
+      timeout: 1s
+
+    pipeline:
+      thread_num: 1
+      processors:
+        - type: "json_to_arrow"
+
+    output:
+      type: "mongodb"
+      uri: "mongodb://localhost:27017"
+      database: "arkflow"
+      collection: "events"
+
+    error_output:
+      type: "stdout"

--- a/examples/mongodb_output_example.yaml
+++ b/examples/mongodb_output_example.yaml
@@ -1,0 +1,6 @@
+# Writes each Arrow row as a BSON document.
+output:
+  type: "mongodb"
+  uri: "mongodb://localhost:27017"
+  database: "arkflow"
+  collection: "events"

--- a/openspec/changes/add-mongodb-output/.openspec.yaml
+++ b/openspec/changes/add-mongodb-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/add-mongodb-output/design.md
+++ b/openspec/changes/add-mongodb-output/design.md
@@ -1,0 +1,41 @@
+## Context
+
+ArkFlow outputs receive columnar Apache Arrow `MessageBatch` values and are initialized through the plugin output registry. MongoDB's Rust driver accepts BSON `Document` values and provides an async `insert_many` operation, so the integration needs an explicit row-to-document conversion boundary and a connection lifecycle matching `Output::connect`/`close`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a small native MongoDB output with URI/database/collection configuration.
+- Preserve Arrow scalar values as BSON values, including nulls, and insert one document per row in each output batch.
+- Keep connection setup in `connect`, serialize writes through a shared collection handle, and classify MongoDB driver errors: network/lifecycle failures as `Error::Connection`, authentication failures as `Error::Authentication`, and server/data failures as `Error::Process`.
+- Make configuration discoverable through component metadata, examples, and documentation.
+
+**Non-Goals:**
+
+- Transactions, retries, upserts, deletes, sharding-aware routing, or change streams.
+- Converting arbitrary Arrow nested structures in the initial implementation.
+- Supporting encoded binary payloads through the MongoDB output codec slot; a configured codec is rejected as unsupported rather than silently discarded.
+
+## Decisions
+
+1. **Use the official `mongodb` Rust driver and its BSON types.** This avoids hand-built BSON serialization and gives async pooling and URI parsing. A custom HTTP/JSON implementation was rejected because it would require reimplementing authentication, pooling, and BSON semantics.
+2. **Use `uri`, `database`, and `collection` as the required configuration.** The URI owns server authentication and driver options; separate database and collection names keep destination selection explicit. A single database URI convention was rejected because it makes YAML validation and UI metadata less clear.
+3. **Map each supported Arrow scalar column to a same-named BSON field.** This preserves the batch schema without a second mapping language. Configurable field mappings were deferred because they are not required for a usable first output and would duplicate processor functionality.
+4. **Call `insert_many` once per `write` batch.** This preserves batch throughput and gives the output a single driver operation per acknowledgement unit. Per-row `insert_one` was rejected for unnecessary round trips; transactions were excluded because they require session handling and a replica-set deployment.
+5. **Reject configured codecs.** MongoDB output writes structured BSON documents, while the codec interface produces encoded bytes or a transformed batch. Rejecting an incompatible codec at build time prevents accidental insertion of opaque payloads.
+
+## Risks / Trade-offs
+
+- [Unsupported Arrow types] → Return a descriptive configuration/process error naming the field and type; cover supported scalar mappings with unit tests.
+- [Partial bulk insertion] → Surface the driver's `insert_many` error so the engine does not acknowledge the failed output batch; document that initial semantics are not transactional.
+- [Driver dependency footprint] → Keep the dependency limited to the async Tokio runtime and default TLS behavior, and run package-level tests/build checks.
+- [Concurrent writes] → Guard the optional collection handle with Tokio's mutex so lifecycle and writes cannot race.
+
+## Migration Plan
+
+Add the dependency and register the new output during normal plugin initialization. Existing configurations are unchanged. Deployments that use MongoDB add an `output` with `type: mongodb`; rollback is deleting that output and reverting the dependency/code change.
+
+## Open Questions
+
+None for the initial implementation.

--- a/openspec/changes/add-mongodb-output/proposal.md
+++ b/openspec/changes/add-mongodb-output/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+ArkFlow currently has relational and key/value database outputs, but no native MongoDB output for persisting Arrow record batches as BSON documents. The output registry exposes only the existing builders in `crates/arkflow-plugin/src/output/mod.rs:21-38`, while the `Output` contract accepts a batch through `write` in `crates/arkflow-core/src/output/mod.rs:29-52`; adding MongoDB support fills this storage integration gap without changing the pipeline contract.
+
+## What Changes
+
+- Add a MongoDB output plugin registered under the `mongodb` output type.
+- Connect to a MongoDB URI and target a configured database and collection.
+- Convert each Arrow row to a BSON document, preserving supported scalar values and representing nulls as BSON null.
+- Insert an output batch with MongoDB bulk insertion and return connection/write failures through ArkFlow errors.
+- Expose component metadata/schema and a configuration example, plus user-facing output documentation.
+- Add unit tests for BSON conversion, configuration validation, registration, and batch behavior.
+
+## Non-goals
+
+- No MongoDB change-stream input or CDC source.
+- No update/upsert/delete semantics, generated `_id` customization, or per-record routing in the initial plugin.
+- No exactly-once guarantee beyond the existing output acknowledgement contract.
+
+## Capabilities
+
+### New Capabilities
+
+- `mongodb-output`: Configure a MongoDB destination and write Arrow batches as BSON documents.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `crates/arkflow-plugin`: new MongoDB output module, registration, dependency, and tests.
+- `docs/docs/components/3-outputs`: MongoDB configuration documentation.
+- `examples`: MongoDB output example.
+- Cargo dependency resolution gains the official Rust MongoDB driver.

--- a/openspec/changes/add-mongodb-output/specs/mongodb-output/spec.md
+++ b/openspec/changes/add-mongodb-output/specs/mongodb-output/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: MongoDB output configuration
+
+The MongoDB output MUST be registered under the `mongodb` type and MUST require a MongoDB URI, database name, and collection name. Invalid or missing configuration MUST fail during output construction with an ArkFlow configuration error.
+
+#### Scenario: Valid destination configuration
+
+- **WHEN** an output is configured with `type: mongodb`, `uri`, `database`, and `collection`
+- **THEN** the builder creates a MongoDB output without connecting yet
+
+#### Scenario: Missing destination configuration
+
+- **WHEN** one of `uri`, `database`, or `collection` is missing or empty
+- **THEN** output construction fails with a configuration error
+
+#### Scenario: Unsupported codec
+
+- **WHEN** a codec is configured on a MongoDB output
+- **THEN** output construction fails with a configuration error explaining that structured BSON output does not support codecs
+
+### Requirement: MongoDB connection lifecycle
+
+The output MUST create its MongoDB client and target collection during `connect`, retain the handle for writes, and release it during `close`. Connection and close failures MUST be returned as ArkFlow errors.
+
+#### Scenario: Connect to destination
+
+- **WHEN** `connect` is called with a valid reachable MongoDB URI
+- **THEN** the output stores a usable collection handle for the configured database and collection
+
+#### Scenario: Write before connect
+
+- **WHEN** `write` is called before a successful `connect`
+- **THEN** the output returns a disconnection/process error and does not acknowledge the batch
+
+### Requirement: Batch rows become BSON documents
+
+For every input row, the output MUST create one BSON document whose fields use the Arrow column names. It MUST preserve non-null UTF-8 strings, signed and unsigned integers, floating-point values, booleans, binary values, and nulls using their corresponding BSON representations. Unsupported Arrow types MUST fail with an error identifying the column.
+
+#### Scenario: Convert scalar row
+
+- **WHEN** a batch contains supported scalar columns and a row has non-null values
+- **THEN** the corresponding BSON document contains the same field names and equivalent BSON values
+
+#### Scenario: Preserve null
+
+- **WHEN** a supported column is null for a row
+- **THEN** the document contains that field with BSON null
+
+#### Scenario: Reject unsupported type
+
+- **WHEN** a row contains an Arrow type not supported by the output
+- **THEN** conversion fails before insertion and identifies the offending field and type
+
+### Requirement: Batch insertion and error propagation
+
+Each successful `write` MUST insert all documents from the input `MessageBatch` with one MongoDB bulk insertion operation. The output MUST classify network/lifecycle driver errors as ArkFlow connection errors, authentication failures as authentication errors, and other insertion failures as process errors. It MUST not report success when insertion fails. Empty batches MUST complete successfully without issuing an insertion.
+
+#### Scenario: Insert non-empty batch
+
+- **WHEN** a connected output receives a batch with one or more rows
+- **THEN** it calls MongoDB bulk insertion with one document per row and returns success after the operation succeeds
+
+#### Scenario: MongoDB insertion fails
+
+- **WHEN** MongoDB rejects the bulk insertion
+- **THEN** `write` returns the appropriate ArkFlow error category containing the driver failure
+
+#### Scenario: Insert empty batch
+
+- **WHEN** a connected output receives a batch with zero rows
+- **THEN** `write` returns success without calling MongoDB

--- a/openspec/changes/add-mongodb-output/tasks.md
+++ b/openspec/changes/add-mongodb-output/tasks.md
@@ -1,0 +1,18 @@
+## 1. Dependency and registration
+
+- [x] 1.1 Add the official MongoDB Rust driver dependency with Tokio support to the workspace/plugin manifests.
+- [x] 1.2 Add the MongoDB output module and register it from the output initializer under `mongodb`.
+
+## 2. MongoDB output implementation
+
+- [x] 2.1 Implement strict URI/database/collection configuration parsing and reject configured codecs.
+- [x] 2.2 Implement connect/close lifecycle with a shared MongoDB collection handle.
+- [x] 2.3 Implement Arrow scalar/null/binary-to-BSON row conversion with descriptive unsupported-type errors.
+- [x] 2.4 Implement empty-batch handling and one-operation-per-batch `insert_many` writes with error propagation.
+- [x] 2.5 Register component schema metadata and a valid configuration example.
+
+## 3. Tests and documentation
+
+- [x] 3.1 Add unit tests for configuration, BSON conversion, null handling, unsupported types, and empty batches.
+- [x] 3.2 Add a MongoDB output YAML example and user-facing output documentation.
+- [x] 3.3 Run formatting, OpenSpec validation, and package/workspace tests; fix any failures.


### PR DESCRIPTION
## Summary

- add a native MongoDB output registered as mongodb
- convert Arrow scalar rows to BSON and insert batches with insert_many
- classify MongoDB connection, authentication, and process errors
- add configuration metadata, docs, example, tests, and OpenSpec artifacts

## Validation

- cargo test -p arkflow-plugin mongodb
- cargo check -p arkflow-plugin
- cargo fmt --all -- --check
- openspec validate add-mongodb-output --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a MongoDB output for writing Arrow records as BSON documents.
  - Supports configurable MongoDB URI, database, and collection settings.
  - Validates connections, performs bulk insertion, and supports common scalar, binary, string, numeric, boolean, and null values.
  - Rejects unsupported data types and oversized numeric values.
  - Added an example configuration for local MongoDB usage.

- **Documentation**
  - Added MongoDB output documentation covering configuration, supported types, limitations, and behavior.

- **Tests**
  - Added coverage for conversion, validation, empty batches, unsupported types, and numeric overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->